### PR TITLE
Use fully qualified name in inventory plugin

### DIFF
--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -55,7 +55,7 @@ e-api-model/master/#types/vm) for available attributes.
 
 EXAMPLES = '''
 # Sample content of ovirt.yml
-# plugin: ovirt
+# plugin: ovirt.ovirt_collection.ovirt
 # ovirt_url: http://localhost/ovirt-engine/api
 # ovirt_username: ansible-tester
 # ovirt_password: secure
@@ -88,7 +88,7 @@ except ImportError:
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
-    NAME = 'ovirt'
+    NAME = 'ovirt.ovirt_collection.ovirt'
 
     def __init__(self):
 


### PR DESCRIPTION
This is a common issue that several collections hit.

Basically, if you don't use the fully qualified name here, there's no way to use this inventory because Ansible core expects it under the collection name.namespace.

I can't yet say that I've tested this, and I don't think I'll get full validation, but I'll try to check back after I manually test and make sure that with an invalid server, it gives the error I would expect.