### PR TITLE
Rename collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 oVirt ansible collection
 ====================================
 
-The `ovirt.ovirt_collection` manages all ansible modules of oVirt.
+The `ovirt.ovirt` manages all ansible modules of oVirt.
 
 Note
 ----
 Please note that when installing this collection from Ansible Galaxy you are instructed to run following command:
 
 ```bash
-$ ansible-galaxy collection install ovirt.ovirt_collection
+$ ansible-galaxy collection install ovirt.ovirt
 ```
 
 
@@ -51,7 +51,7 @@ Example Playbook
         state: present
         cluster: Default
   collections:
-    - ovirt.ovirt_collection
+    - ovirt.ovirt
 ```
 License
 -------

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -26,7 +26,7 @@ rpmbuild \
 find output -iname \*rpm -exec mv "{}" exported-artifacts/ \;
 mv *.tar.gz exported-artifacts
 
-COLLECTION_DIR="/usr/local/share/ansible/collections/ansible_collections/ovirt/ovirt_collection"
+COLLECTION_DIR="/usr/local/share/ansible/collections/ansible_collections/ovirt/ovirt"
 mkdir -p $COLLECTION_DIR
 cp -r $PWD/* $COLLECTION_DIR
 cd $COLLECTION_DIR

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ VERSION="1.0.0"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 
-COLLECTION_NAME="ovirt_collection"
+COLLECTION_NAME="ovirt"
 COLLECTION_NAMESPACE="ovirt"
 
 PACKAGE_NAME="ovirt-ansible-collection"

--- a/examples/ovirt_ansible_collections.yml
+++ b/examples/ovirt_ansible_collections.yml
@@ -18,4 +18,4 @@
         state: present
         cluster: Default
   collections:
-    - ovirt.ovirt_collection
+    - ovirt.ovirt

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "ovirt"
-name: "ovirt_collection"
-version: 1.0.1
+name: "ovirt"
+version: 1.0.0
 authors:
     - Martin Necas <mnecas@redhat.com>
 license_file: ./LICENSE

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -1,5 +1,5 @@
 %global namespace ovirt
-%global collectionname ovirt_collection
+%global collectionname ovirt
 %global ansible_collections_dir ansible/collections/ansible_collections
 
 Name: @PACKAGE_NAME@

--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 # Ensure the CA is available:
 # $ wget "https://engine/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA" -O /path/to/ca.pem
 # Sample content of ovirt.yml:
-plugin: ovirt.ovirt_collection.ovirt
+plugin: ovirt.ovirt.ovirt
 ovirt_url: https://engine/ovirt-engine/api
 ovirt_cafile: /path/to/ca.pem
 ovirt_username: ansible-tester
@@ -98,7 +98,7 @@ except ImportError:
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
-    NAME = 'ovirt.ovirt_collection.ovirt'
+    NAME = 'ovirt.ovirt.ovirt'
 
     def _get_dict_of_struct(self, vm):
         '''  Transform SDK Vm Struct type to Python dictionary.

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -26,7 +26,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from distutils.version import LooseVersion
 
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.cloud import CloudRetry
+from ansible_collections.ovirt.ovirt.plugins.module_utils.cloud import CloudRetry
 from ansible.module_utils.common._collections_compat import Mapping
 
 try:

--- a/plugins/modules/ovirt_affinity_group.py
+++ b/plugins/modules/ovirt_affinity_group.py
@@ -64,7 +64,7 @@ options:
         description:
             - List of the hosts names, which should have assigned this affinity group.
             - This parameter is support since oVirt/RHV 4.1 version.
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -126,7 +126,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_support,

--- a/plugins/modules/ovirt_affinity_label.py
+++ b/plugins/modules/ovirt_affinity_label.py
@@ -54,7 +54,7 @@ options:
     hosts:
         description:
             - "List of the hosts names, which should have assigned this affinity label."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -105,7 +105,7 @@ except ImportError:
 
 from collections import defaultdict
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_affinity_label_info.py
+++ b/plugins/modules/ovirt_affinity_label_info.py
@@ -48,7 +48,7 @@ options:
     host:
       description:
         - "Name of the host, which affinity labels should be listed."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -100,7 +100,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_api_info.py
+++ b/plugins/modules/ovirt_api_info.py
@@ -29,7 +29,7 @@ notes:
     - "This module returns a variable C(ovirt_api),
        which contains a information about oVirt/RHV API. You need to register the result with
        the I(register) keyword to use it."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -56,7 +56,7 @@ ovirt_api:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_auth.py
+++ b/plugins/modules/ovirt_auth.py
@@ -204,7 +204,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import check_sdk
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import check_sdk
 
 
 def main():

--- a/plugins/modules/ovirt_cluster.py
+++ b/plugins/modules/ovirt_cluster.py
@@ -259,7 +259,7 @@ options:
                and relevant only for clusters with Gluster service."
             - "Could be for example I(virtual-host), I(rhgs-sequential-io), I(rhgs-random-io)"
         type: str
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -335,7 +335,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_cluster_info.py
+++ b/plugins/modules/ovirt_cluster_info.py
@@ -46,7 +46,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search cluster X from datacenter Y use following pattern:
            name=X and datacenter=Y"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -73,7 +73,7 @@ ovirt_clusters:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_datacenter.py
+++ b/plugins/modules/ovirt_datacenter.py
@@ -65,7 +65,7 @@ options:
         default: False
         type: bool
 
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -111,7 +111,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_datacenter_info.py
+++ b/plugins/modules/ovirt_datacenter_info.py
@@ -30,7 +30,7 @@ options:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search datacenter I(X) use following pattern: I(name=X)"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -56,7 +56,7 @@ ovirt_datacenters:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -183,7 +183,7 @@ options:
             - I(True) if the disk should be activated.
             - When creating disk of virtual machine it is set to I(True).
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 
@@ -316,7 +316,7 @@ try:
 except ImportError:
     pass
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_disk_info.py
+++ b/plugins/modules/ovirt_disk_info.py
@@ -44,7 +44,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search Disk X from storage Y use following pattern:
            name=X and storage.name=Y"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -70,7 +70,7 @@ ovirt_disks:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_event.py
+++ b/plugins/modules/ovirt_event.py
@@ -93,7 +93,7 @@ options:
         description:
             - "The id of the VM associated with this event."
         type: str
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -144,7 +144,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_event_info.py
+++ b/plugins/modules/ovirt_event_info.py
@@ -70,7 +70,7 @@ options:
         required: false
         default: true
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -106,7 +106,7 @@ ovirt_events:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_external_provider.py
+++ b/plugins/modules/ovirt_external_provider.py
@@ -95,7 +95,7 @@ options:
                of them defined in the system they will be removed."
             - "Applicable for I(os_volume)."
         default: []
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -184,7 +184,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_params,
     check_sdk,

--- a/plugins/modules/ovirt_external_provider_info.py
+++ b/plugins/modules/ovirt_external_provider_info.py
@@ -47,7 +47,7 @@ options:
     name:
         description:
             - "Name of the external provider, can be used as glob expression."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -83,7 +83,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_group.py
+++ b/plugins/modules/ovirt_group.py
@@ -51,7 +51,7 @@ options:
         description:
             - "Namespace of the authorization provider, where group resides."
         required: false
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -99,7 +99,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_group_info.py
+++ b/plugins/modules/ovirt_group_info.py
@@ -43,7 +43,7 @@ options:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search group X use following pattern: name=X"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -69,7 +69,7 @@ ovirt_groups:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_host.py
+++ b/plugins/modules/ovirt_host.py
@@ -163,7 +163,7 @@ options:
             - If I(separated), each vGPU is placed on a separate physical card, if
               possible. This can be useful for improving vGPU performance.
         choices: ['consolidated', 'separated']
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -291,7 +291,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_host_info.py
+++ b/plugins/modules/ovirt_host_info.py
@@ -42,7 +42,7 @@ options:
         - "Filter the hosts based on the cluster version."
       type: str
 
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -76,7 +76,7 @@ ovirt_hosts:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -118,7 +118,7 @@ options:
             - "If I(true) all networks will be synchronized before modification"
         type: bool
         default: false
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -221,7 +221,7 @@ except ImportError:
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_host_pm.py
+++ b/plugins/modules/ovirt_host_pm.py
@@ -58,7 +58,7 @@ options:
     order:
         description:
             - "Integer value specifying, by default it's added at the end."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -120,7 +120,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -55,7 +55,7 @@ options:
             lun_id:
                 description:
                   - "LUN id."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -89,7 +89,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_instance_type.py
+++ b/plugins/modules/ovirt_instance_type.py
@@ -174,7 +174,7 @@ options:
             - "Memory balloon is a guest device, which may be used to re-distribute / reclaim the host memory
                based on instance type needs in a dynamic way. In this way it's possible to create memory over commitment states."
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -244,7 +244,7 @@ instancetype:
 from ansible.module_utils.basic import AnsibleModule
 import traceback
 
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_params,
     check_sdk,

--- a/plugins/modules/ovirt_job.py
+++ b/plugins/modules/ovirt_job.py
@@ -61,7 +61,7 @@ options:
                 choices: ['present', 'absent', 'started', 'finished', 'failed']
                 default: present
         type: list
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -116,7 +116,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     equal,

--- a/plugins/modules/ovirt_mac_pool.py
+++ b/plugins/modules/ovirt_mac_pool.py
@@ -44,7 +44,7 @@ options:
         description:
             - "List of MAC ranges. The from and to should be split by comma."
             - "For example: 00:1a:4a:16:01:51,00:1a:4a:16:01:61"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -91,7 +91,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     equal,

--- a/plugins/modules/ovirt_network.py
+++ b/plugins/modules/ovirt_network.py
@@ -101,7 +101,7 @@ options:
     label:
         description:
             - "Name of the label to assign to the network."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -154,7 +154,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_network_info.py
+++ b/plugins/modules/ovirt_network_info.py
@@ -45,7 +45,7 @@ options:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search network starting with string vlan1 use: name=vlan1*"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 
@@ -73,7 +73,7 @@ ovirt_networks:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_nic.py
+++ b/plugins/modules/ovirt_nic.py
@@ -58,7 +58,7 @@ options:
         description:
             - Defines if the NIC is linked to the virtual machine.
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -132,7 +132,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_nic_info.py
+++ b/plugins/modules/ovirt_nic_info.py
@@ -48,7 +48,7 @@ options:
     name:
         description:
             - "Name of the NIC, can be used as glob expression."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -76,7 +76,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_permission.py
+++ b/plugins/modules/ovirt_permission.py
@@ -74,7 +74,7 @@ options:
     quota_name:
         description:
             - Name of the quota to assign permission. Works only with C(object_type) I(data_center).
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -140,7 +140,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_permission_info.py
+++ b/plugins/modules/ovirt_permission_info.py
@@ -56,7 +56,7 @@ options:
         description:
             - "Namespace of the authorization provider, where user/group resides."
         required: false
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -88,7 +88,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_link_name,

--- a/plugins/modules/ovirt_quota.py
+++ b/plugins/modules/ovirt_quota.py
@@ -84,7 +84,7 @@ options:
             size:
                 description:
                     - Size limit (in GiB).
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -152,7 +152,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_quota_info.py
+++ b/plugins/modules/ovirt_quota_info.py
@@ -46,7 +46,7 @@ options:
     name:
         description:
             - "Name of the quota, can be used as glob expression."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -74,7 +74,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_role.py
+++ b/plugins/modules/ovirt_role.py
@@ -40,7 +40,7 @@ options:
             - "List of permits which role will have"
             - "Permit 'login' is default and all roles will have it."
             - "List can contain name of permit."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -76,7 +76,7 @@ ovirt_role:
     type: list
 '''
 
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     convert_to_bytes,

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -46,7 +46,7 @@ options:
     name:
         description:
             - "Name of the scheduling policy, can be used as glob expression."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -75,7 +75,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_snapshot.py
+++ b/plugins/modules/ovirt_snapshot.py
@@ -102,7 +102,7 @@ notes:
        machine - it simply removes a return-point. However, restoring a virtual
        machine from a snapshot deletes any content that was written to the
        virtual machine after the time the snapshot was taken."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 
@@ -199,7 +199,7 @@ from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_snapshot_info.py
+++ b/plugins/modules/ovirt_snapshot_info.py
@@ -37,7 +37,7 @@ options:
     snapshot_id:
         description:
             - "Id of the snapshot we want to retrieve information about."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -66,7 +66,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_storage_connection.py
+++ b/plugins/modules/ovirt_storage_connection.py
@@ -70,7 +70,7 @@ options:
             - "If I(true) the storage domain don't have to be in I(MAINTENANCE)
                state, so the storage connection is updated."
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -117,7 +117,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_storage_domain.py
+++ b/plugins/modules/ovirt_storage_domain.py
@@ -211,7 +211,7 @@ options:
             - "If I(True) storage domain blocks will be discarded upon deletion. Enabled by default."
             - "This parameter is relevant only for block based storage domains."
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -384,7 +384,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_storage_domain_info.py
+++ b/plugins/modules/ovirt_storage_domain_info.py
@@ -46,7 +46,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search storage domain X from datacenter Y use following pattern:
            name=X and datacenter=Y"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -73,7 +73,7 @@ ovirt_storage_domains:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_storage_template_info.py
+++ b/plugins/modules/ovirt_storage_template_info.py
@@ -51,7 +51,7 @@ options:
     storage_domain:
         description:
             - "The storage domain name where the templates should be listed."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -78,7 +78,7 @@ ovirt_storage_templates:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_storage_vm_info.py
+++ b/plugins/modules/ovirt_storage_vm_info.py
@@ -51,7 +51,7 @@ options:
     storage_domain:
         description:
             - "The storage domain name where the virtual machines should be listed."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -78,7 +78,7 @@ ovirt_storage_vms:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_tag.py
+++ b/plugins/modules/ovirt_tag.py
@@ -61,7 +61,7 @@ options:
     hosts:
         description:
             - "List of the hosts names, which should have assigned this tag."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -126,7 +126,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_tag_info.py
+++ b/plugins/modules/ovirt_tag_info.py
@@ -50,7 +50,7 @@ options:
     host:
       description:
         - "Name of the host, which tags should be listed."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -91,7 +91,7 @@ import fnmatch
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_template.py
+++ b/plugins/modules/ovirt_template.py
@@ -336,7 +336,7 @@ options:
             root_password:
                 description:
                     - Password to be set for username to Windows Virtual Machine.
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -527,7 +527,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     convert_to_bytes,

--- a/plugins/modules/ovirt_template_info.py
+++ b/plugins/modules/ovirt_template_info.py
@@ -46,7 +46,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search template X from datacenter Y use following pattern:
            name=X and datacenter=Y"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -73,7 +73,7 @@ ovirt_templates:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_user.py
+++ b/plugins/modules/ovirt_user.py
@@ -51,7 +51,7 @@ options:
         description:
             - "Namespace where the user resides. When using the authorization provider that stores users in the LDAP server,
                this attribute equals the naming context of the LDAP server."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -97,7 +97,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     check_params,

--- a/plugins/modules/ovirt_user_info.py
+++ b/plugins/modules/ovirt_user_info.py
@@ -43,7 +43,7 @@ options:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search user X use following pattern: name=X"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -69,7 +69,7 @@ ovirt_users:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -820,7 +820,7 @@ notes:
       When user specify I(absent) C(state), we forcibly stop the VM in any state and remove it.
     - "If you update a VM parameter that requires a reboot, the oVirt engine always creates a new snapshot for the VM,
       and an Ansible playbook will report this as changed."
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -1230,7 +1230,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_params,
     check_sdk,

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -65,7 +65,7 @@ options:
            the virtual machine with the modifications that have already been performed but that will only come into
            effect when the virtual machine is restarted. By default the value is set by engine."
       type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -100,7 +100,7 @@ ovirt_vms:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_vmpool.py
+++ b/plugins/modules/ovirt_vmpool.py
@@ -146,7 +146,7 @@ options:
                     - C(mac_address) - Custom MAC address of the network interface, by default it's obtained from MAC pool.
                     - NOTE - This parameter is used only when C(state) is I(running) or I(present) and is able to only create NICs.
                     - To manage NICs of the VM in more depth please use M(ovirt_nics) module instead.
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -229,7 +229,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_params,
     check_sdk,

--- a/plugins/modules/ovirt_vmpool_info.py
+++ b/plugins/modules/ovirt_vmpool_info.py
@@ -45,7 +45,7 @@ options:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search vmpool X: name=X"
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -71,7 +71,7 @@ ovirt_vm_pools:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/ovirt_vnic_profile.py
+++ b/plugins/modules/ovirt_vnic_profile.py
@@ -74,7 +74,7 @@ options:
         description:
             - "Marks whether pass_through NIC is migratable or not."
         type: bool
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt
+extends_documentation_fragment: ovirt.ovirt.ovirt
 '''
 
 EXAMPLES = '''
@@ -144,7 +144,7 @@ except ImportError:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     BaseModule,
     check_sdk,
     create_connection,

--- a/plugins/modules/ovirt_vnic_profile_info.py
+++ b/plugins/modules/ovirt_vnic_profile_info.py
@@ -48,7 +48,7 @@ options:
         description:
             - "Name of vnic profile."
         type: str
-extends_documentation_fragment: ovirt.ovirt_collection.ovirt_info
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
 '''
 
 EXAMPLES = '''
@@ -74,7 +74,7 @@ ovirt_vnic_profiles:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,


### PR DESCRIPTION
After a request from the ansible core team https://github.com/oVirt/ovirt-ansible-collection/issues/14. We have decided to rename `ovirt.ovirt_collection` to `ovirt.ovirt`.

cc @mwperina 