### PR TITLE
ovirt_disk: add upload image warning for correct format

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -734,7 +734,7 @@ def main():
             # Upload disk image in case it's new disk or force parameter is passed:
             if module.params['upload_image_path'] and (is_new_disk or module.params['force']):
                 if module.params['format'] == 'cow' and module.params['content_type'] == 'iso':
-                    module.warn("Parameter 'format' should not be 'cow' when uploading iso image, please change it to 'raw'.")
+                    module.warn("To upload an ISO image 'format' parameter needs to be set to 'raw'.")
                 uploaded = upload_disk_image(connection, module)
                 ret['changed'] = ret['changed'] or uploaded
             # Download disk image in case it's file don't exist or force parameter is passed:

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -58,6 +58,7 @@ options:
                if you want to upload the disk even if the disk with C(id) or C(name) exists,
                then please use C(force) I(true). If you will use C(force) I(false), which
                is default, then the disk image won't be uploaded."
+            - "Note that to upload iso the C(format) should be 'raw'"
     size:
         description:
             - "Size of the disk. Size should be specified using IEC standard units.
@@ -78,7 +79,6 @@ options:
         description:
             - Specify if the disk is a data disk or ISO image or a one of a the Hosted Engine disk types
             - The Hosted Engine disk content types are available with Engine 4.3+ and Ansible 2.8
-            - Note when using 'iso' the C(format) should be 'raw'.
         choices: ['data', 'iso', 'hosted_engine', 'hosted_engine_sanlock', 'hosted_engine_metadata', 'hosted_engine_configuration']
         default: 'data'
     sparse:

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -73,10 +73,12 @@ options:
             - Specify format of the disk.
             - Note that this option isn't idempotent as it's not currently possible to change format of the disk via API.
         choices: ['raw', 'cow']
+        default: 'cow'
     content_type:
         description:
             - Specify if the disk is a data disk or ISO image or a one of a the Hosted Engine disk types
             - The Hosted Engine disk content types are available with Engine 4.3+ and Ansible 2.8
+            - Note when using 'iso' the C(format) should be 'raw'.
         choices: ['data', 'iso', 'hosted_engine', 'hosted_engine_sanlock', 'hosted_engine_metadata', 'hosted_engine_configuration']
         default: 'data'
     sparse:
@@ -731,6 +733,8 @@ def main():
 
             # Upload disk image in case it's new disk or force parameter is passed:
             if module.params['upload_image_path'] and (is_new_disk or module.params['force']):
+                if module.params['format'] == 'cow' and module.params['content_type'] == 'iso':
+                    module.warn("Parameter 'format' should not be 'cow' when uploading iso image, please change it to 'raw'.")
                 uploaded = upload_disk_image(connection, module)
                 ret['changed'] = ret['changed'] or uploaded
             # Download disk image in case it's file don't exist or force parameter is passed:

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -37,7 +37,6 @@ plugins/modules/ovirt_datacenter_info.py validate-modules:doc-missing-type
 plugins/modules/ovirt_disk.py future-import-boilerplate
 plugins/modules/ovirt_disk.py metaclass-boilerplate
 plugins/modules/ovirt_disk.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/ovirt_disk.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/ovirt_disk.py validate-modules:doc-missing-type
 plugins/modules/ovirt_disk.py validate-modules:parameter-type-not-in-doc
 plugins/modules/ovirt_disk.py validate-modules:undocumented-parameter


### PR DESCRIPTION
Add warning when uploading iso and the format is cow, before this PR the upload would end on FINALIZING_FAILURE and no more information, now it shows warning which will inform the user to update to raw.

@mwperina  @dangel101