### PR TITLE
Update operating system options

### DIFF
--- a/plugins/modules/ovirt_instance_type.py
+++ b/plugins/modules/ovirt_instance_type.py
@@ -72,13 +72,15 @@ options:
         description:
             - Operating system of the Instance Type.
             - Default value is set by oVirt/RHV engine.
-            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux,
-               other_linux_ppc64, other_ppc64, rhel_3, rhel_4, rhel_4x64, rhel_5, rhel_5x64,
-               rhel_6, rhel_6x64, rhel_6_ppc64, rhel_7x64, rhel_7_ppc64, sles_11, sles_11_ppc64,
-               ubuntu_12_04, ubuntu_12_10, ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64,
-               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008, windows_2008x64,
-               windows_2008r2x64, windows_2008R2x64, windows_2012x64, windows_2012R2x64, windows_7,
-               windows_7x64, windows_8, windows_8x64, windows_xp"
+            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
+               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
+               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
+               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
+               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
+               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
+               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
+               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
+               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     boot_devices:
         description:
             - List of boot devices which should be used to boot. For example C([ cdrom, hd ]).

--- a/plugins/modules/ovirt_template.py
+++ b/plugins/modules/ovirt_template.py
@@ -148,14 +148,15 @@ options:
         description:
             - Operating system of the template.
             - Default value is set by oVirt/RHV engine.
-            - "Possible values are: debian_7, freebsd, freebsdx64, other, other_linux,
-               other_linux_ppc64, other_ppc64, rhel_3, rhel_4, rhel_4x64, rhel_5, rhel_5x64,
-               rhel_6, rhel_6x64, rhel_6_ppc64, rhel_7x64, rhel_7_ppc64, sles_11,
-               sles_11_ppc64, ubuntu_12_04, ubuntu_12_10, ubuntu_13_04, ubuntu_13_10,
-               ubuntu_14_04, ubuntu_14_04_ppc64, windows_10, windows_10x64, windows_2003,
-               windows_2003x64, windows_2008, windows_2008x64, windows_2008r2x64,
-               windows_2008R2x64, windows_2012x64, windows_2012R2x64,
-               windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
+            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
+               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
+               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
+               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
+               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
+               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
+               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
+               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
+               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     memory:
         description:
             - Amount of memory of the template. Prefix uses IEC 60027-2 standard (for example 1GiB, 1024MiB).

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -197,13 +197,15 @@ options:
         description:
             - Operating system of the Virtual Machine.
             - Default value is set by oVirt/RHV engine.
-            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux,
-               other_linux_ppc64, other_ppc64, rhel_3, rhel_4, rhel_4x64, rhel_5, rhel_5x64,
-               rhel_6, rhel_6x64, rhel_6_ppc64, rhel_7x64, rhel_7_ppc64, sles_11, sles_11_ppc64,
-               ubuntu_12_04, ubuntu_12_10, ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64,
-               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008, windows_2008x64,
-               windows_2008r2x64, windows_2008R2x64, windows_2012x64, windows_2012R2x64, windows_7,
-               windows_7x64, windows_8, windows_8x64, windows_xp"
+            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
+               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
+               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
+               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
+               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
+               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
+               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
+               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
+               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     boot_devices:
         description:
             - List of boot devices which should be used to boot. For example C([ cdrom, hd ]).


### PR DESCRIPTION
Updates various modules with the current (4.4) list.

other_linux_kernel_4
other_linux_s390x
other_s390x
rhcos_x64
rhel_3x64
rhel_6_9_plus_ppc64
rhel_7_s390x
rhel_8x64
rhel_atomic7x64
sles_12_s390x
ubuntu_16_04_s390x
windows_2016x64
windows_2019x64

Removed (incorrect and duplicate):

windows_2008r2x64