### PR TITLE
Add ovirt_vm_os_info

### DIFF
--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -55,7 +55,7 @@ def check_sdk(module):
         )
 
 
-def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None):
+def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None):
     """
     Convert SDK Struct type into dictionary.
     """
@@ -127,7 +127,10 @@ def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=N
                 continue
 
             key = remove_underscore(key)
-            res[key] = convert_value(value)
+            if filter_keys is None:
+                res[key] = convert_value(value)
+            elif key in filter_keys:
+                res[key] = convert_value(value)
 
     return res
 

--- a/plugins/modules/ovirt_instance_type.py
+++ b/plugins/modules/ovirt_instance_type.py
@@ -72,6 +72,7 @@ options:
         description:
             - Operating system of the Instance Type.
             - Default value is set by oVirt/RHV engine.
+            - Use the ovirt_vm_os_info module to obtain the current list.
             - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
                other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
                rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,

--- a/plugins/modules/ovirt_instance_type.py
+++ b/plugins/modules/ovirt_instance_type.py
@@ -70,18 +70,9 @@ options:
             - Default value is set by oVirt/RHV engine.
     operating_system:
         description:
-            - Operating system of the Instance Type.
+            - Operating system of the Instance Type, for example 'rhel_8x64'.
             - Default value is set by oVirt/RHV engine.
             - Use the ovirt_vm_os_info module to obtain the current list.
-            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
-               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
-               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
-               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
-               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
-               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
-               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
-               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
-               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     boot_devices:
         description:
             - List of boot devices which should be used to boot. For example C([ cdrom, hd ]).

--- a/plugins/modules/ovirt_template.py
+++ b/plugins/modules/ovirt_template.py
@@ -148,6 +148,7 @@ options:
         description:
             - Operating system of the template.
             - Default value is set by oVirt/RHV engine.
+            - Use the ovirt_vm_os_info module to obtain the current list.
             - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
                other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
                rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,

--- a/plugins/modules/ovirt_template.py
+++ b/plugins/modules/ovirt_template.py
@@ -146,18 +146,9 @@ options:
         type: bool
     operating_system:
         description:
-            - Operating system of the template.
+            - Operating system of the template, for example 'rhel_8x64'.
             - Default value is set by oVirt/RHV engine.
             - Use the ovirt_vm_os_info module to obtain the current list.
-            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
-               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
-               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
-               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
-               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
-               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
-               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
-               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
-               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     memory:
         description:
             - Amount of memory of the template. Prefix uses IEC 60027-2 standard (for example 1GiB, 1024MiB).

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -197,6 +197,7 @@ options:
         description:
             - Operating system of the Virtual Machine.
             - Default value is set by oVirt/RHV engine.
+            - Use the ovirt_vm_os_info module to obtain the current list.
             - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
                other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
                rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -195,18 +195,9 @@ options:
             - "Virtual Machine quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
     operating_system:
         description:
-            - Operating system of the Virtual Machine.
+            - Operating system of the Virtual Machine, for example 'rhel_8x64'.
             - Default value is set by oVirt/RHV engine.
             - Use the ovirt_vm_os_info module to obtain the current list.
-            - "Possible values: debian_7, freebsd, freebsdx64, other, other_linux, other_linux_kernel_4,
-               other_linux_ppc64, other_linux_s390x, other_ppc64, other_s390x, rhcos_x64, rhel_3,
-               rhel_3x64, rhel_4, rhel_4x64, rhel_5, rhel_5x64, rhel_6, rhel_6_9_plus_ppc64,
-               rhel_6_ppc64, rhel_6x64, rhel_7_ppc64, rhel_7_s390x, rhel_7x64, rhel_8x64,
-               rhel_atomic7x64, sles_11, sles_11_ppc64, sles_12_s390x, ubuntu_12_04, ubuntu_12_10,
-               ubuntu_13_04, ubuntu_13_10, ubuntu_14_04, ubuntu_14_04_ppc64, ubuntu_16_04_s390x,
-               windows_10, windows_10x64, windows_2003, windows_2003x64, windows_2008,
-               windows_2008R2x64, windows_2008x64, windows_2012R2x64, windows_2012x64, windows_2016x64,
-               windows_2019x64, windows_7, windows_7x64, windows_8, windows_8x64, windows_xp"
     boot_devices:
         description:
             - List of boot devices which should be used to boot. For example C([ cdrom, hd ]).

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_vm_os_info
+short_description: Retrieve information on all supported oVirt/RHV operating systems
+version_added: "1.0.1"
+author:
+- "Martin Necas (@mnecas)"
+- "Chris Brown (@snecklifter)"
+description:
+    - "Retrieve information on all supported oVirt/RHV operating systems."
+notes:
+    - "This module returns a variable C(ovirt_operating_systems), which
+       contains a list of operating systems. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    filter_keys:
+      description:
+        - "List of attributes which should be in returned."
+      type: list
+    name:
+      description:
+        - "Name of the operating system which should be returned."
+      type: str
+extends_documentation_fragment: ovirt.ovirt.ovirt_info
+'''
+
+EXAMPLES = '''
+# Look at ovirt_auth module to see how to reuse authentication:
+
+- ovirt_vm_os_info:
+    auth: "{{ ovirt_auth }}"
+  register: result
+- debug:
+    msg: "{{ result.ovirt_operating_systems }}"
+
+- ovirt_vm_os_info:
+    auth: "{{ ovirt_auth }}"
+    filter_keys: name,architecture
+  register: result
+- debug:
+    msg: "{{ result.ovirt_operating_systems }}"
+'''
+
+RETURN = '''
+ovirt_operating_systems:
+    description: "List of dictionaries describing the operating systems. Operating system attributes are mapped to dictionary keys,
+                  all operating systems attributes can be found at following url:
+                  http://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        filter_keys=dict(default=None, type='list'),
+        name=dict(default=None, type='str'),
+    )
+    module = AnsibleModule(argument_spec)
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        operating_systems_service = connection.system_service().operating_systems_service()
+        operating_systems = operating_systems_service.list()
+        if module.params['name']:
+            operating_systems = filter(lambda x: x.name == module.params['name'], operating_systems)
+        result = dict(
+            ovirt_operating_systems=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                    filter_keys=module.params['filter_keys'],
+                ) for c in operating_systems
+            ],
+        )
+        module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add ovirt_vm_os_info as suggested in https://github.com/oVirt/ovirt-ansible-collection/pull/24
Not sure if this is the best use case, but still wanted to add the PR where we could discuss it.

Right now the module return list of dictionaries which have attributes like name, architecture etc. in [1].
When I tried to get a list of all supported OS names it was so large list with all attributes that I did have to add filter_keys to filter the output. For example, the `large_icon` and `small_icon` attributes are unnecessary for ansible (you can check them in [1] or /ovirt-engine/api/operatingsystems).
To specific attributes like a name (you can check examples). 

example of the output
```
 "ovirt_vm_os": [
        {
            "architecture": "x86_64",
            "description": "Other OS",
            "href": "/ovirt-engine/api/operatingsystems/0",
            "id": "0",
            "large_icon": {
                "href": "/ovirt-engine/api/icons/2ef463ea-7c28-49e1-b977-471eaf087d1e",
                "id": "2ef463ea-7c28-49e1-b977-471eaf087d1e"
            },
            "name": "other",
            "small_icon": {
                "href": "/ovirt-engine/api/icons/1f91726e-f467-463e-936a-46c19d6e96a2",
                "id": "1f91726e-f467-463e-936a-46c19d6e96a2"
            }
        },
        {
            "architecture": "x86_64",
            "description": "Windows XP",
            "href": "/ovirt-engine/api/operatingsystems/1",
            "id": "1",
            "large_icon": {
                "href": "/ovirt-engine/api/icons/e00ddcc3-2728-26a2-09b8-49740dfc7b9b",
                "id": "e00ddcc3-2728-26a2-09b8-49740dfc7b9b"
            },
            "name": "windows_xp",
            "small_icon": {
                "href": "/ovirt-engine/api/icons/8ef03a05-2ed5-12a2-efa1-eead0d9c0644",
                "id": "8ef03a05-2ed5-12a2-efa1-eead0d9c0644"
            }
        }
    ]

```


**Questions** 
- if I should only return simply a list of names or keep it like it is.
- if I should return ovirt_vm_os or ovirt_vm_oss, because everywhere we return plural of it but don't like the doubles. 




[1] http://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info

@mwperina @dangel101 @snecklifter