### PR TITLE
ovirt_host_network: fix save of network config

### DIFF
--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -579,7 +579,7 @@ def main():
                     ] if labels else None,
                     removed_network_attachments=attachments if attachments else None,
                 )
-                if engine_supported(connection, '4.3'):
+                if engine_supported(connection, '4.4'):
                     setup_params['commit_on_success'] = module.params['save']
                 elif module.params['save']:
                     setup_params['post_action'] = host_networks_module._action_save_configuration


### PR DESCRIPTION
This is a workaround to allow save until the fixed in the engine.
Proper fixed should be in https://bugzilla.redhat.com/show_bug.cgi?id=1798818
https://github.com/ansible/ansible/issues/67810
@dangel101 @mwperina 