### PR TITLE
Support direct upload/download to Image I/O daemon on oVirt node

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -337,6 +337,7 @@ from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     get_dict_of_struct,
     search_by_name,
     wait,
+    engine_supported,
 )
 
 
@@ -371,7 +372,7 @@ def transfer(connection, module, direction, transfer_func):
             time.sleep(module.params['poll_interval'])
             transfer = transfer_service.get()
 
-        if module.params['use_proxy']:
+        if module.params['use_proxy'] or not engine_supported(connection, '4.4'):
             destination_url = urlparse(transfer.proxy_url)
         else:
             destination_url = urlparse(transfer.transfer_url)
@@ -672,7 +673,7 @@ def main():
         host=dict(default=None),
         wipe_after_delete=dict(type='bool', default=None),
         activate=dict(default=None, type='bool'),
-        use_proxy=dict(default=False, type='bool'),
+        use_proxy=dict(default=None, type='bool'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -355,7 +355,8 @@ def create_transfer_connection(module, transfer, context, connect_timeout=10, re
         connection.connect()
     except OSError as e:
         # Typically ConnectionRefusedError or socket.gaierror.
-        module.warn("Cannot connect to %s, trying %s: %s", transfer.transfer_url, transfer.proxy_url, e)
+        module.warn("Cannot connect to {}, trying {}: {}"
+                    .format(transfer.transfer_url, transfer.proxy_url, e))
 
         url = urlparse(transfer.proxy_url)
         connection = HTTPSConnection(


### PR DESCRIPTION
Fixes #29 and therefore fixes image down-/upload on oVirt 4.4 engines also see [RHBZ 1801710](https://bugzilla.redhat.com/show_bug.cgi?id=1801710).

I verified this code with the following testing playbook:
```
---                                                                                                                                                                                                                                                                                                                   
- hosts: localhost
  connection: local                   
  gather_facts: False
                                                                               
  collections:
    - ovirt.ovirt

  tasks:
    - ovirt_auth:
        url: https://ovirt.example.com/ovirt-engine/api
        username: admin@internal
        password: password

    - ovirt_disk:
        auth: '{{ ovirt_auth }}'
        name: testdisk
        size: 10GiB
        format: cow
        upload_image_path: /tmp/testdisk.img
        storage_domain: vmstore

    - ovirt_disk:
        auth: '{{ ovirt_auth }}'
        name: testdisk
        download_image_path: /tmp/testdisk-1.img
        storage_domain: vmstore

    - ovirt_auth:
        ovirt_auth: '{{ ovirt_auth }}'
        state: absent
```
Before this patch this playbook would fail with the following error when run against a oVirt 4.4 API:
```
TASK [ovirt_disk] ******************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ConnectionRefusedError: [Errno 111] Connection refused
fatal: [localhost]: FAILED! => {"changed": false, "msg": "[Errno 111] Connection refused"}
```
I also needed to [remove the authentication header](https://github.com/ganto/ovirt-ansible-collection/commit/f281406f3273a49ad9c072fd913fc5a3c9d0b1e0#diff-dfc3119277e6ad415795e92381e14ef8L421) from the download request. Otherwise I would get an error like:
```
The full traceback is:                                                                                                                                                                                                                                                                                                        
Traceback (most recent call last):                                                                                                                                                                                                                                                                                            
  File "/tmp/ansible_ovirt_disk_payload_wyxbh_tl/ansible_ovirt_disk_payload.zip/ansible_collections/ovirt/ovirt/plugins/modules/ovirt_disk.py", line 753, in main                                                                                                                                                             
  File "/tmp/ansible_ovirt_disk_payload_wyxbh_tl/ansible_ovirt_disk_payload.zip/ansible_collections/ovirt/ovirt/plugins/modules/ovirt_disk.py", line 454, in download_disk_image                                                                                                                                              
  File "/tmp/ansible_ovirt_disk_payload_wyxbh_tl/ansible_ovirt_disk_payload.zip/ansible_collections/ovirt/ovirt/plugins/modules/ovirt_disk.py", line 396, in transfer                                                                                                                                                         
  File "/tmp/ansible_ovirt_disk_payload_wyxbh_tl/ansible_ovirt_disk_payload.zip/ansible_collections/ovirt/ovirt/plugins/modules/ovirt_disk.py", line 435, in _transfer                                                                                                                                                        
  File "/usr/lib/python3.7/http/client.py", line 1262, in request                                                                                                                                                                                                                                                             
    self._send_request(method, url, body, headers, encode_chunked)                                                                                                                                                                                                                                                            
  File "/usr/lib/python3.7/http/client.py", line 1303, in _send_request                                                                                                                                                                                                                                                       
    self.putheader(hdr, value)                                                                                                                                                                                                                                                                                                
  File "/usr/lib/python3.7/http/client.py", line 1239, in putheader                                                                                                                                                                                                                                                           
    if _is_illegal_header_value(values[i]):                                                                                                                                                                                                                                                                                   
TypeError: expected string or bytes-like object
```
I don't don't understand what is going wrong here. Maybe someone can make some sense of this?

Unfortunately I don't have a oVirt 4.3 environment around for testing the `use_proxy` flag. ~~Also not sure if this should be enabled or disabled by default. Is there some way to autodetect this and do the right thing for 4.3 and 4.4?~~