### PR TITLE
Respect constructed strict option

### DIFF
--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -217,9 +217,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for fact, value in host.items():
                 self.inventory.set_variable(hostname, fact, value)
 
-            self._set_composite_vars(self.get_option('compose'), host, hostname)
-            self._add_host_to_composed_groups(self.get_option('groups'), host, hostname)
-            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname)
+            strict = self.get_option('strict')
+            self._set_composite_vars(self.get_option('compose'), host, hostname, strict=strict)
+            self._add_host_to_composed_groups(self.get_option('groups'), host, hostname, strict=strict)
+            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
 
     def verify_file(self, path):
 


### PR DESCRIPTION
Tested locally by doing things like:

```yaml
plugin: ovirt.ovirt.ovirt
ovirt_hostname_preference:
 - name
 - fqdn
strict: true
compose:
  ansible_host: '(devices.values() | list)[0][0] if devices else None'
  foobar: 'sefe or esfes'
```

so then it fails because "foobar" is nonsense, then

```yaml
plugin: ovirt.ovirt.ovirt
ovirt_hostname_preference:
 - name
 - fqdn
strict: false
compose:
  ansible_host: '(devices.values() | list)[0][0] if devices else None'
  foobar: 'sefe or esfes'
```

works fine, because it ignores the nonsense entry.

This is also a pretty standard pattern in other inventory plugins. It's already in the options, because it comes from the constructed doc fragment.