### PR TITLE
Use imageio client when uploading disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,16 @@ Please note that when installing this collection from Ansible Galaxy you are ins
 $ ansible-galaxy collection install ovirt.ovirt
 ```
 
-
 Requirements
 ------------
 
- * Ansible version 2.9 or higher
- * Python SDK version 4.3 or higher
+ * ansible >= 2.9.0
+ * python3-ovirt-engine-sdk4 >= 4.4.0
+ * ovirt-imageio-client >= 2.0.5
 
 Modules documentation
 --------------
 https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#ovirt
-
-Dependencies
-------------
-
-None.
 
 Example Playbook
 ----------------

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -14,7 +14,7 @@ Url:            http://www.ovirt.org
 
 Requires: ansible >= 2.9.0
 Requires: python3-ovirt-engine-sdk4 >= 4.4.0
-Requires: ovirt-imageio-common >= 2.0.5
+Requires: ovirt-imageio-client >= 2.0.5
 
 %description
 This Ansible collection is to manage all ovirt modules and inventory

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -14,6 +14,7 @@ Url:            http://www.ovirt.org
 
 Requires: ansible >= 2.9.0
 Requires: python3-ovirt-engine-sdk4 >= 4.4.0
+Requires: ovirt-imageio-common >= 2.0.5
 
 %description
 This Ansible collection is to manage all ovirt modules and inventory

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -340,7 +340,6 @@ from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
     search_by_name,
     wait,
 )
-from ovirt_imageio import client
 
 
 def _search_by_lun(disks_service, lun_id):
@@ -356,6 +355,7 @@ def _search_by_lun(disks_service, lun_id):
 
 
 def transfer(connection, module, direction):
+    from ovirt_imageio import client
     transfers_service = connection.system_service().image_transfers_service()
     transfer = transfers_service.add(
         otypes.ImageTransfer(

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -317,10 +317,7 @@ disk_attachment:
 import os
 import time
 import traceback
-import ssl
 
-from ansible.module_utils.six.moves.http_client import HTTPSConnection, IncompleteRead
-from ansible.module_utils.six.moves.urllib.parse import urlparse
 try:
     import ovirtsdk4.types as otypes
 except ImportError:

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -360,6 +360,7 @@ def transfer(connection, module, direction):
                 id=module.params['id'],
             ),
             direction=direction,
+            format=otypes.DiskFormat.RAW,
         )
     )
     transfer_service = transfers_service.image_transfer_service(transfer.id)

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -699,6 +699,7 @@ def main():
                     otypes.ImageTransferDirection.DOWNLOAD
                 )
                 ret['changed'] = ret['changed'] or downloaded
+            disks_module.changed = ret['changed']
 
             # Disk sparsify, only if disk is of image type:
             if not module.check_mode:

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -383,7 +383,6 @@ def transfer(connection, module, direction):
                 module.params['download_image_path'],
                 auth.get('ca_file'),
                 fmt='qcow2' if module.params['format'] == 'cow' else 'raw',
-                incremental=module.params['format'] == 'cow',
                 secure=not auth.get('insecure'),
             )
         else:

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -317,7 +317,7 @@ import time
 import traceback
 import ssl
 
-from ovirt_imageio import client
+
 from ansible.module_utils.six.moves.http_client import HTTPSConnection, IncompleteRead
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 try:
@@ -426,6 +426,7 @@ def download_disk_image(connection, module):
     def _transfer(transfer_service, proxy_connection, proxy_url, transfer):
         path = module.params['download_image_path']
         if engine_supported(connection, '4.4'):
+            from ovirt_imageio import client
             auth = module.params['auth']
             if module.params['use_proxy']:
                 destination_url = transfer.proxy_url
@@ -472,6 +473,7 @@ def upload_disk_image(connection, module):
     def _transfer(transfer_service, proxy_connection, proxy_url, transfer):
         path = module.params['upload_image_path']
         if engine_supported(connection, '4.4'):
+            from ovirt_imageio import client
             auth = module.params['auth']
             if module.params['use_proxy']:
                 destination_url = transfer.proxy_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ansible>=2.9.0
+python3-ovirt-engine-sdk4>=4.4.0
+ovirt-imageio-client>=2.0.5

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -36,10 +36,6 @@ plugins/modules/ovirt_datacenter_info.py metaclass-boilerplate
 plugins/modules/ovirt_datacenter_info.py validate-modules:doc-missing-type
 plugins/modules/ovirt_disk.py future-import-boilerplate
 plugins/modules/ovirt_disk.py metaclass-boilerplate
-plugins/modules/ovirt_disk.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/ovirt_disk.py validate-modules:doc-missing-type
-plugins/modules/ovirt_disk.py validate-modules:parameter-type-not-in-doc
-plugins/modules/ovirt_disk.py validate-modules:undocumented-parameter
 plugins/modules/ovirt_disk_info.py future-import-boilerplate
 plugins/modules/ovirt_disk_info.py metaclass-boilerplate
 plugins/modules/ovirt_disk_info.py validate-modules:doc-missing-type

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -36,6 +36,10 @@ plugins/modules/ovirt_datacenter_info.py metaclass-boilerplate
 plugins/modules/ovirt_datacenter_info.py validate-modules:doc-missing-type
 plugins/modules/ovirt_disk.py future-import-boilerplate
 plugins/modules/ovirt_disk.py metaclass-boilerplate
+plugins/modules/ovirt_disk.py validate-modules:doc-choices-do-not-match-spec
+plugins/modules/ovirt_disk.py validate-modules:doc-missing-type
+plugins/modules/ovirt_disk.py validate-modules:parameter-type-not-in-doc
+plugins/modules/ovirt_disk.py validate-modules:undocumented-parameter
 plugins/modules/ovirt_disk_info.py future-import-boilerplate
 plugins/modules/ovirt_disk_info.py metaclass-boilerplate
 plugins/modules/ovirt_disk_info.py validate-modules:doc-missing-type


### PR DESCRIPTION
Fixes #29 
Continuing of the https://github.com/oVirt/ovirt-ansible-collection/pull/35

This raises a minor issue when installing from galaxy there will be missing the `ovirt-imageio-client` python library because we cannot specify dependency of rpm.
I have moved the import to the transfer function so it would only fail when trying to upload/download.

@mwperina @dangel101 @nirs
cc @ganto 