### PR TITLE
ovirt_disk: force wait when uploading disk

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -724,6 +724,7 @@ def main():
                 result_state=otypes.DiskStatus.OK if lun is None else None,
                 fail_condition=lambda d: d.status == otypes.DiskStatus.ILLEGAL if lun is None else False,
                 force_create=force_create,
+                _wait = True if module.params['upload_image_path'] else module.params['wait'],
             )
             is_new_disk = ret['changed']
             ret['changed'] = ret['changed'] or disks_module.update_storage_domains(ret['id'])

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -724,7 +724,7 @@ def main():
                 result_state=otypes.DiskStatus.OK if lun is None else None,
                 fail_condition=lambda d: d.status == otypes.DiskStatus.ILLEGAL if lun is None else False,
                 force_create=force_create,
-                _wait = True if module.params['upload_image_path'] else module.params['wait'],
+                _wait=True if module.params['upload_image_path'] else module.params['wait'],
             )
             is_new_disk = ret['changed']
             ret['changed'] = ret['changed'] or disks_module.update_storage_domains(ret['id'])


### PR DESCRIPTION
Force `wait` parameter to `True` when creating a disk to which will be image uploaded.
Fixes https://github.com/oVirt/ovirt-ansible-collection/issues/28
https://github.com/ansible/ansible/issues/68487
@dangel101 @mwperina 