### PR TITLE
Set inventory plugin insecure if no cafile defined

### DIFF
--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -244,7 +244,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             username=self.get_option('ovirt_username'),
             password=self.get_option('ovirt_password'),
             ca_file=self.get_option('ovirt_cafile'),
-            insecure=self.get_option('ovirt_insecure'),
+            insecure=not self.get_option('ovirt_cafile'),
         )
 
         query_filter = self._get_query_options(self.get_option('ovirt_query_filter', None))

--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -47,7 +47,6 @@ DOCUMENTATION = '''
       ovirt_insecure:
         description: A boolean flag that indicates if the server TLS certificate and host name should be checked.
         required: False
-        default: False
       ovirt_query_filter:
         required: False
         description: dictionary of filter key-values to query VM's. See U(https://ovirt.github.io/ovirt-engine-sdk/master/services.m.html#ovirtsdk4\
@@ -244,7 +243,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             username=self.get_option('ovirt_username'),
             password=self.get_option('ovirt_password'),
             ca_file=self.get_option('ovirt_cafile'),
-            insecure=not self.get_option('ovirt_cafile'),
+            insecure=self.get_option('ovirt_insecure') if self.get_option('ovirt_insecure') is not None else not self.get_option('ovirt_cafile'),
         )
 
         query_filter = self._get_query_options(self.get_option('ovirt_query_filter', None))


### PR DESCRIPTION
In Tower 3.7, I was running into an issue with a self signed certificate on my RHV cluster. Disabling secure connections when the cafile is not defined fixes this issue, in the same way that it worked in previous versions of Tower with the ovirt4 inventory plugin.