### PR TITLE
Update ovirt_vm_info.py - enable tags

### DIFF
--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -128,6 +128,7 @@ def main():
             all_content=module.params['all_content'],
             case_sensitive=module.params['case_sensitive'],
             max=module.params['max'],
+            follow='tags',
         )
         if module.params['next_run']:
             vms = [vms_service.vm_service(vm.id).get(next_run=True) for vm in vms]


### PR DESCRIPTION
Currently, tags dict is empty when retrieving info on VMs.  This enables the vms_service.list() method to follow the tags link and return the tag data.