### PR TITLE
ovirt_disk: fix activate

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -724,7 +724,7 @@ def main():
         if state in ('present', 'detached', 'attached'):
             # Always activate disk when its being created
             if vm_service is not None and disk is None:
-                module.params['activate'] = True
+                module.params['activate'] = module.params['activate'] is None or module.params['activate']
             ret = disks_module.create(
                 entity=disk if not force_create else None,
                 result_state=otypes.DiskStatus.OK if lun is None else None,


### PR DESCRIPTION
Issue: was not able to attach the deactivated disk to the VM
This keeps previous logic the same (default is activated) but when specifying the value it will overwrite it.
@mwperina @dangel101