### PR TITLE
ovirt_host_network: fix custom_properties default value

### DIFF
--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -530,7 +530,7 @@ def main():
                             otypes.Property(
                                 name=prop.get('name'),
                                 value=prop.get('value')
-                            ) for prop in network.get('custom_properties')
+                            ) for prop in network.get('custom_properties', [])
                         ]
                     ) for network in networks
                 ] if networks else None,


### PR DESCRIPTION
the issue occurred in infra role when not specified custom_properties it failed with error not able to iterate through None 