### PR TITLE
ovirt_vm: fix cd_iso get all disks from storage domains

### DIFF
--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1669,7 +1669,7 @@ class VmsModule(BaseModule):
             else:
                 continue
             disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and
-                                (x.content_type == otypes.DiskContentType.ISO or sd.type == otypes.StorageDomainType.ISO),
+                                (sd.type == otypes.StorageDomainType.ISO or x.content_type == otypes.DiskContentType.ISO),
                                 self._connection.follow_link(disks)))
             if disks:
                 return disks

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1662,7 +1662,9 @@ class VmsModule(BaseModule):
 
     def __get_cds_from_sds(self, sds):
         for sd in sds:
-            disks = list(filter(lambda x: x.name == self.param('cd_iso') and x.content_type == otypes.DiskContentType.ISO,
+            if sd.disks is None:
+                continue
+            disks = list(filter(lambda x: x.name == self.param('cd_iso') or x.id == self.param('cd_iso') and x.content_type == otypes.DiskContentType.ISO,
                                 self._connection.follow_link(sd.disks)))
             if disks:
                 return disks
@@ -1671,12 +1673,11 @@ class VmsModule(BaseModule):
         sds_service = self._connection.system_service().storage_domains_service()
         sds = sds_service.list(search='name="{}"'.format(self.param('storage_domain') if self.param('storage_domain') else "*"))
         disks = self.__get_cds_from_sds(sds)
-        if len(disks) > 1:
+        if disks and len(disks) > 1:
             raise ValueError('Found mutiple disks with same name "{}" please use \
                 disk ID in "cd_iso" to specify which disk should be used.'.format(self.param('cd_iso')))
         if not disks:
-            # The `cd_iso` is valid disk ID returning to _attach_cd
-            return disks_service.disk_service(self.param('cd_iso')).get().id
+            raise ValueError('Was not able to find disk with name or id "{}".'.format(self.param('cd_iso')))
         return disks[0].id
 
     def _attach_cd(self, entity):

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1673,11 +1673,11 @@ class VmsModule(BaseModule):
         sds_service = self._connection.system_service().storage_domains_service()
         sds = sds_service.list(search='name="{}"'.format(self.param('storage_domain') if self.param('storage_domain') else "*"))
         disks = self.__get_cds_from_sds(sds)
-        if disks and len(disks) > 1:
-            raise ValueError('Found mutiple disks with same name "{}" please use \
-                disk ID in "cd_iso" to specify which disk should be used.'.format(self.param('cd_iso')))
         if not disks:
             raise ValueError('Was not able to find disk with name or id "{}".'.format(self.param('cd_iso')))
+        if len(disks) > 1:
+            raise ValueError('Found mutiple disks with same name "{}" please use \
+                disk ID in "cd_iso" to specify which disk should be used.'.format(self.param('cd_iso')))
         return disks[0].id
 
     def _attach_cd(self, entity):

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1664,13 +1664,12 @@ class VmsModule(BaseModule):
         for sd in sds:
             if sd.type == otypes.StorageDomainType.ISO:
                 disks = sd.files
-                is_iso = lambda x: True
             elif sd.type == otypes.StorageDomainType.DATA:
                 disks = sd.disks
-                is_iso = lambda x: x.content_type == otypes.DiskContentType.ISO
             else:
                 continue
-            disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and is_iso(x),
+            disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and
+                                (x.content_type == otypes.DiskContentType.ISO or sd.type == otypes.StorageDomainType.ISO),
                                 self._connection.follow_link(disks)))
             if disks:
                 return disks

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -282,7 +282,7 @@ options:
     cd_iso:
         description:
             - ISO file from ISO storage domain which should be attached to Virtual Machine.
-            - If you have multiple ISO disks with the same name use disk ID to specify which should be used.
+            - If you have multiple ISO disks with the same name use disk ID to specify which should be used or use C(storage_domain) to filter disks.
             - If you pass empty string the CD will be ejected from VM.
             - If used with C(state) I(running) or I(present) and VM is running the CD will be attached to VM.
             - If used with C(state) I(running) or I(present) and VM is down the CD will be attached to VM persistently.
@@ -1660,9 +1660,16 @@ class VmsModule(BaseModule):
         self._wait_for_UP(vm_service)
         self._attach_cd(vm_service.get())
 
+    def __get_cds_from_sds(self, sds):
+        for sd in sds:
+            disks = list(filter(lambda x: x.name==self.param('cd_iso') and x.content_type==otypes.DiskContentType.ISO, self._connection.follow_link(sd.disks)))
+            if disks:
+                return disks
+
     def __get_cd_id(self):
-        disks_service = self._connection.system_service().disks_service()
-        disks = disks_service.list(search='name="{}"'.format(self.param('cd_iso')))
+        sds_service = self._connection.system_service().storage_domains_service()
+        sds = sds_service.list(search='name="{}"'.format(self.param('storage_domain') if self.param('storage_domain') else "*"))
+        disks = self.__get_cds_from_sds(sds)
         if len(disks) > 1:
             raise ValueError('Found mutiple disks with same name "{}" please use \
                 disk ID in "cd_iso" to specify which disk should be used.'.format(self.param('cd_iso')))

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1664,7 +1664,7 @@ class VmsModule(BaseModule):
         for sd in sds:
             if sd.disks is None:
                 continue
-            disks = list(filter(lambda x: x.name == self.param('cd_iso') or x.id == self.param('cd_iso') and x.content_type == otypes.DiskContentType.ISO,
+            disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and x.content_type == otypes.DiskContentType.ISO,
                                 self._connection.follow_link(sd.disks)))
             if disks:
                 return disks

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1662,7 +1662,8 @@ class VmsModule(BaseModule):
 
     def __get_cds_from_sds(self, sds):
         for sd in sds:
-            disks = list(filter(lambda x: x.name==self.param('cd_iso') and x.content_type==otypes.DiskContentType.ISO, self._connection.follow_link(sd.disks)))
+            disks = list(filter(lambda x: x.name == self.param('cd_iso') and x.content_type == otypes.DiskContentType.ISO,
+                                self._connection.follow_link(sd.disks)))
             if disks:
                 return disks
 

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1662,10 +1662,16 @@ class VmsModule(BaseModule):
 
     def __get_cds_from_sds(self, sds):
         for sd in sds:
-            if sd.disks is None:
+            if sd.type == otypes.StorageDomainType.ISO:
+                disks = sd.files
+                is_iso = lambda x: True
+            elif sd.type == otypes.StorageDomainType.DATA:
+                disks = sd.disks
+                is_iso = lambda x: x.content_type == otypes.DiskContentType.ISO
+            else:
                 continue
-            disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and x.content_type == otypes.DiskContentType.ISO,
-                                self._connection.follow_link(sd.disks)))
+            disks = list(filter(lambda x: (x.name == self.param('cd_iso') or x.id == self.param('cd_iso')) and is_iso(x),
+                                self._connection.follow_link(disks)))
             if disks:
                 return disks
 


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/62
Issue: in 4.3 the disks from ISO storage domain were not able to get from disks_service to make it backward compatible did need to gather all storage domains
@mwperina @dangel101
