### PR TITLE
Add execution environment metadata

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,2 @@
+libxml2-devel [platform:rpm]
+python3-pycurl [platform:rpm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ovirt-engine-sdk-python>=4.4.0


### PR DESCRIPTION
This adds data to allow users to add `ovirt.ovirt` to a new thing called Execution Environments in a way that makes its content usable.

Some specifics of the expected contract are laid out in the project https://github.com/ansible/ansible-builder, this is a CLI tool which will take collections inside a user's definition and spit out a container image. This image can then be used in executors using `ansible-runner`.

Since this collection is a part of the inventory options in AWX and Ansible Tower, this collection is a part of our base test case. Some initial smoke test to assure that the `HAS_` variable from module_utils will come out to be `True`:

```
$ docker run --rm --tty --interactive exec-env-pycurl python3 -c "import ovirtsdk4.version as sdk_version; print(sdk_version.VERSION)"
4.4.4
```