### PR TITLE
Rename q35_sea to q35_sea_bios

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -242,7 +242,3 @@ releases:
     release_date: '2020-08-12'
   1.1.2:
     release_date: '2020-08-17'
-  1.1.3:
-    changes:
-      bugfixes:
-      - ovirt_vm - Rename q35_sea to q35_sea_bios (https://github.com/oVirt/ovirt-ansible-collection/pull/111).

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -242,3 +242,7 @@ releases:
     release_date: '2020-08-12'
   1.1.2:
     release_date: '2020-08-17'
+  1.1.3:
+    changes:
+      bugfixes:
+      - ovirt_vm - Rename q35_sea to q35_sea_bios (https://github.com/oVirt/ovirt-ansible-collection/pull/111).

--- a/changelogs/fragments/ovirt_vm-rename-q35_sea.yml
+++ b/changelogs/fragments/ovirt_vm-rename-q35_sea.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ovirt-vm - Rename q35_sea to q35_sea_bios (https://github.com/oVirt/ovirt-ansible-collection/pull/111).
+  - ovirt_vm - Rename q35_sea to q35_sea_bios (https://github.com/oVirt/ovirt-ansible-collection/pull/111).

--- a/changelogs/fragments/ovirt_vm-rename-q35_sea.yml
+++ b/changelogs/fragments/ovirt_vm-rename-q35_sea.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt-vm - Rename q35_sea to q35_sea_bios (https://github.com/oVirt/ovirt-ansible-collection/pull/111).

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -262,7 +262,7 @@ options:
             - "Set bios type, necessary for some operating systems and secure boot."
             - "If no value is passed, default value is set from cluster."
             - "NOTE - Supported since oVirt 4.3."
-        choices: [ i440fx_sea_bios, q35_ovmf, q35_sea, q35_secure_boot ]
+        choices: [ i440fx_sea_bios, q35_ovmf, q35_sea_bios, q35_secure_boot ]
         type: str
     usb_support:
         description:
@@ -2454,7 +2454,7 @@ def main():
         domain_mappings=dict(default=[], type='list', elements='dict'),
         reassign_bad_macs=dict(default=None, type='bool'),
         boot_menu=dict(type='bool'),
-        bios_type=dict(type='str', choices=['i440fx_sea_bios', 'q35_ovmf', 'q35_sea', 'q35_secure_boot']),
+        bios_type=dict(type='str', choices=['i440fx_sea_bios', 'q35_ovmf', 'q35_sea_bios', 'q35_secure_boot']),
         serial_console=dict(type='bool'),
         usb_support=dict(type='bool'),
         sso=dict(type='bool'),


### PR DESCRIPTION
To be aligned with the oVirt's API

Signed-off-by: Arik Hadas <ahadas@redhat.com>