### PR TITLE
ovirt_disk: fix upload when direct upload fails

### DIFF
--- a/changelogs/fragments/ovirt_disk-fix-upload-when-direct-upload-fails.yml
+++ b/changelogs/fragments/ovirt_disk-fix-upload-when-direct-upload-fails.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_disk - fix upload when direct upload fails (https://github.com/oVirt/ovirt-ansible-collection/pull/120).

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -404,7 +404,7 @@ def create_transfer_connection(module, transfer, context, connect_timeout=10, re
         url.netloc, context=context, timeout=connect_timeout)
     try:
         connection.connect()
-    except OSError as e:
+    except Exception as e:
         # Typically ConnectionRefusedError or socket.gaierror.
         module.warn("Cannot connect to %s, trying %s: %s" % (transfer.transfer_url, transfer.proxy_url, e))
 


### PR DESCRIPTION
There were multiple possible exceptions when trying to connect to the engine for direct upload to the host.
This fixes the issue and solves any other unexpected errors.
https://bugzilla.redhat.com/show_bug.cgi?id=1879165