### PR TITLE
Add connection close at the end of inventory sync

### DIFF
--- a/changelogs/fragments/ovirt-inventory-add-connection-close.yml
+++ b/changelogs/fragments/ovirt-inventory-add-connection-close.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt inventory - Add close of connection at the end (https://github.com/oVirt/ovirt-ansible-collection/pull/122).

--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -267,3 +267,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._cache[cache_key] = source_data
 
         self._populate_from_source(source_data)
+        self.connection.close()


### PR DESCRIPTION
# Problem

During our usage of Ansible Tower and Inventory Sync operations against RHV we saw following:
```
1- We do inv sync frequently
2- Our RHV had sessions timeout after an hour
3- so it held onto all connections in the db and JVM (java )
4- connections pile up
```
This connection piling up is not good for environment as it uses resources unnecessarily. 

It is important we close out connection at the end.

# Solution

Close the connection at the end of sync.