### PR TITLE
added the option to set different compatibility version for data center and for cluster

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-add-compatibility_version.yml
+++ b/changelogs/fragments/hosted_engine_setup-add-compatibility_version.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - Add compatibility_version (https://github.com/oVirt/ovirt-ansible-collection/pull/125).

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -30,7 +30,9 @@ Ansible role for deploying oVirt Hosted-Engine
 | he_pki_renew_on_restore | false | Renew engine PKI on restore if needed |
 | he_cluster | Default | name of the cluster with hosted-engine hosts |
 | he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as HE host or lower) |
+| he_cluster_comp_version | null | Compatibility version of the hosted-engine cluster. Default value is the latest compatibility version |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
+| he_data_center_comp_version | null | Compatibility version of the hosted-engine data center. Default value is the latest compatibility version |
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -50,6 +50,7 @@
     ovirt_datacenter:
       state: present
       name: "{{ he_data_center }}"
+      compatibility_version: "{{ he_data_center_comp_version | default(omit) }}"
       wait: true
       local: false
       auth: "{{ ovirt_auth }}"
@@ -58,6 +59,7 @@
     ovirt_cluster:
       state: present
       name: "{{ he_cluster }}"
+      compatibility_version: "{{ he_cluster_comp_version | default(omit) }}"
       data_center: "{{ he_data_center }}"
       cpu_type: "{{ he_cluster_cpu_type | default(omit) }}"
       wait: true
@@ -75,6 +77,7 @@
     ovirt_cluster:
       data_center: "{{ he_data_center }}"
       name: "{{ he_cluster }}"
+      compatibility_version: "{{ he_cluster_comp_version | default(omit) }}"
       auth: "{{ ovirt_auth }}"
       virt: true
       gluster: true


### PR DESCRIPTION
in the latest version of 4.4, we have a new data center and cluster compatibility version - 4.5
by default, we use the latest data center and cluster compatibility version - 4.5
but we need also the option to define the hosted engine to stay with compatibility version 4.4