### PR TITLE
Set hosted-engine VM with custom bios type (Q35+SeaBIOS)

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-set-custom-bios-type.yml
+++ b/changelogs/fragments/hosted_engine_setup-set-custom-bios-type.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - set custom bios type of hosted-engine VM to Q35+SeaBIOS (https://github.com/oVirt/ovirt-ansible-collection/pull/129).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -201,6 +201,7 @@
         protocol: "{{ he_graphic_protocols }}"
       serial_console: false
       operating_system: rhel_8x64
+      bios_type: q35_sea_bios
       type: server
       high_availability_priority: 1
       high_availability: false


### PR DESCRIPTION
To prevent its bios type from changing when the cluster's bios type changes

Bug-Url: https://bugzilla.redhat.com/1871694
Signed-off-by: Arik Hadas <ahadas@redhat.com>