### PR TITLE
roles: hosted_engine_setup: Use zcat instead of gzip

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-use-zcat-instead-of-gzip.yml
+++ b/changelogs/fragments/hosted_engine_setup-use-zcat-instead-of-gzip.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - use zcat instead of gzip (https://github.com/oVirt/ovirt-ansible-collection/pull/130).

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -63,7 +63,7 @@
         changed_when: true
         register: local_vm_dir_space_out
       - name: Check appliance size
-        shell: gzip -l "{{ he_appliance_ova_path }}" | grep -v uncompressed | awk '{print $2}'
+        shell: zcat "{{ he_appliance_ova_path }}" | wc --bytes
         environment: "{{ he_cmd_lang }}"
         changed_when: true
         register: appliance_size


### PR DESCRIPTION
Use zcat instead of gzip to check the size of the appliance
gzip reports incorrect uncompressed sizes for large files

Bug-Url: https://bugzilla.redhat.com/1821425
Signed-off-by: Asaf Rachmani <arachman@redhat.com>