### PR TITLE
Force Basic Auth for REST API calls

### DIFF
--- a/changelogs/fragments/basic_auth-fix_create_target_hosted_engine_vm.yml
+++ b/changelogs/fragments/basic_auth-fix_create_target_hosted_engine_vm.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 01_create_target_hosted_engine_vm - Force basic authentication (https://github.com/oVirt/ovirt-ansible-collection/pull/131).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -71,6 +71,7 @@
         "https://{{ he_fqdn }}/ovirt-engine/api/options/ServerCPUList?version=\
         {{ cluster_version.major }}.{{ cluster_version.minor }}"
       validate_certs: false
+      force_basic_auth: true
       user: admin@internal
       password: "{{ he_admin_password }}"
       method: GET
@@ -88,6 +89,7 @@
         "https://{{ he_fqdn }}/ovirt-engine/api/options/ClusterEmulatedMachines?version=\
         {{ cluster_version.major }}.{{ cluster_version.minor }}"
       validate_certs: false
+      force_basic_auth: true
       user: admin@internal
       password: "{{ he_admin_password }}"
       method: GET


### PR DESCRIPTION
Force basic authentication when request server CPU list and emulated machine list via REST API. This is needed cause when restoring an engine from backup, where aaa-authentication was configured, the task will fail cause the REST API call will try to negotiate.