### PR TITLE
ovirt_disk: dont move disk when already in storage_domain

### DIFF
--- a/changelogs/fragments/ovirt_disk-fix-move.yml
+++ b/changelogs/fragments/ovirt_disk-fix-move.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_disk - dont move disk when already in storage_domain (https://github.com/oVirt/ovirt-ansible-collection/pull/135)

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -606,6 +606,8 @@ class DisksModule(BaseModule):
         # Initiate move:
         if self._module.params['storage_domain']:
             new_disk_storage_id = get_id_by_name(sds_service, self._module.params['storage_domain'])
+            if new_disk_storage_id in [sd.id for sd in disk.storage_domains]:
+                return changed
             changed = self.action(
                 action='move',
                 entity=disk,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1883817
@mwperina @arachmani 