### PR TITLE
repositories: fix gpg key

### DIFF
--- a/roles/repositories/README.md
+++ b/roles/repositories/README.md
@@ -11,6 +11,7 @@ Role Variables
 | Name                                       | Default value         |  Description                              |
 |--------------------------------------------|-----------------------|-------------------------------------------|
 | ovirt_repositories_ovirt_release_rpm       | UNDEF                 | URL of oVirt release package, which contains required repositories configuration. |
+| ovirt_repositories_ovirt_release_rpm_gpg   | https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2 | Address of the rpm GPG key. |
 | ovirt_repositories_use_subscription_manager| False                 | If true it will use repos from subscription manager and the value of <i>ovirt_repositories_ovirt_release_rpm</i> will be ignored. |
 | ovirt_repositories_ovirt_version           | 4.4                   | oVirt release version (Supported versions [4.1, 4.2, 4.3, 4.4]). Will be used to enable the required repositories and enable modules. |
 | ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |

--- a/roles/repositories/defaults/main.yml
+++ b/roles/repositories/defaults/main.yml
@@ -9,3 +9,4 @@ ovirt_repositories_target_host: engine
 ovirt_repositories_subscription_manager_repos: []
 ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools"]
 ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12"]
+ovirt_repositories_ovirt_release_rpm_gpg: https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2

--- a/roles/repositories/tasks/rpm.yml
+++ b/roles/repositories/tasks/rpm.yml
@@ -1,4 +1,8 @@
 ---
+- rpm_key:
+    state: present
+    name: "{{ ovirt_repositories_ovirt_release_rpm_gpg }}"
+
 - name: Install oVirt release package
   package:
     name: "{{ ovirt_repositories_ovirt_release_rpm | mandatory }}"

--- a/roles/repositories/tasks/rpm.yml
+++ b/roles/repositories/tasks/rpm.yml
@@ -7,6 +7,7 @@
   package:
     name: "{{ ovirt_repositories_ovirt_release_rpm | mandatory }}"
     state: present
+    disable_gpg_check: "{% if 'master.rpm' in ovirt_repositories_ovirt_release_rpm %}True{% else %}False{% endif %}"
 
 - name: Enable dnf modules
   command: "dnf module enable -y {{ ovirt_repositories_ovirt_dnf_modules | join(' ') }}"

--- a/roles/repositories/tasks/rpm.yml
+++ b/roles/repositories/tasks/rpm.yml
@@ -1,7 +1,7 @@
 ---
 - rpm_key:
     state: present
-    name: "{{ ovirt_repositories_ovirt_release_rpm_gpg }}"
+    key: "{{ ovirt_repositories_ovirt_release_rpm_gpg }}"
 
 - name: Install oVirt release package
   package:

--- a/roles/repositories/tasks/rpm.yml
+++ b/roles/repositories/tasks/rpm.yml
@@ -1,5 +1,6 @@
 ---
-- rpm_key:
+- name: Use oVirt GPG key
+  rpm_key:
     state: present
     key: "{{ ovirt_repositories_ovirt_release_rpm_gpg }}"
 


### PR DESCRIPTION
The `disable_gpg_check` was added because of the master rpm are not signed by the gpg key
@mwperina 