### PR TITLE
ovirt_vm_info: add current_cd

### DIFF
--- a/changelogs/fragments/ovirt_vm_info-add-current_cd.yml
+++ b/changelogs/fragments/ovirt_vm_info-add-current_cd.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ovirt_vm_info - Add current_cd (https://github.com/oVirt/ovirt-ansible-collection/pull/144).
+

--- a/changelogs/fragments/ovirt_vm_info-add-current_cd.yml
+++ b/changelogs/fragments/ovirt_vm_info-add-current_cd.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - ovirt_vm_info - Add current_cd (https://github.com/oVirt/ovirt-ansible-collection/pull/144).
-

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -112,6 +112,7 @@ def main():
     argument_spec = ovirt_info_full_argument_spec(
         pattern=dict(default='', required=False),
         all_content=dict(default=False, type='bool'),
+        current_cd=dict(default=False, type='bool'),
         next_run=dict(default=None, type='bool'),
         case_sensitive=dict(default=True, type='bool'),
         max=dict(default=None, type='int'),
@@ -142,6 +143,18 @@ def main():
                 ) for c in vms
             ],
         )
+        for i, vm in enumerate(result['ovirt_vms']):
+            if module.params['current_cd']:
+                vm_service = vms_service.vm_service(vm['id'])
+                cdroms_service = vm_service.cdroms_service()
+                cdrom_device = cdroms_service.list()[0]
+                cdrom_service = cdroms_service.cdrom_service(cdrom_device.id)
+                result['ovirt_vms'][i]['current_cd'] = get_dict_of_struct(
+                    struct=cdrom_service.get(current=True),
+                    connection=connection,
+                )
+            else:
+                result['ovirt_vms'][i]['current_cd'] = {}
         module.exit_json(changed=False, **result)
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -69,6 +69,7 @@ options:
       description:
         - "If I(true) it will get from all virtual machines current attached cd."
       type: bool
+      version_added: 1.2.0
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -65,6 +65,10 @@ options:
            the virtual machine with the modifications that have already been performed but that will only come into
            effect when the virtual machine is restarted. By default the value is set by engine."
       type: bool
+    current_cd:
+      description:
+        - "If I(true) it will get from all virtual machines current attached cd."
+      type: bool
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 


### PR DESCRIPTION
This PR adds usage of `current_cd` to the ovirt_vm_info. 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1885542 


Potential outputs:
when VM does not have any current_cd
```
            "current_cd": {
                "href": "/ovirt-engine/api/vms/293e855c-4477-41d3-959b-47e39ee120e4/cdroms/00000000-0000-0000-0000-000000000000",
                "id": "00000000-0000-0000-0000-000000000000",
                "vm": {
                    "href": "/ovirt-engine/api/vms/293e855c-4477-41d3-959b-47e39ee120e4",
                    "id": "293e855c-4477-41d3-959b-47e39ee120e4"
                }
            },
```
when `current_cd` is disabled
```
            "current_cd": {},
```
when VM does have current_cd
```
            "current_cd": {
                "file": {
                    "id": "CentOS-8.2.2004-x86_64-minimal.iso"
                },
                "href": "/ovirt-engine/api/vms/52b02ec8-95ba-4f2f-b6bb-4de2fd283fa2/cdroms/00000000-0000-0000-0000-000000000000",
                "id": "00000000-0000-0000-0000-000000000000",
                "vm": {
                    "href": "/ovirt-engine/api/vms/52b02ec8-95ba-4f2f-b6bb-4de2fd283fa2",
                    "id": "52b02ec8-95ba-4f2f-b6bb-4de2fd283fa2"
                }
            },

```