### PR TITLE
fix the build path to copy all files into correct path

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -13,7 +13,7 @@ mkdir -p ../ovirt-build ../rhv-build
 ./build.sh build ovirt ../ovirt-build
 ./build.sh build rhv ../rhv-build
 
-cd ../ovirt-build
+cd $ROOT_PATH/ovirt-build/ansible_collections/ovirt/ovirt/
 # create the src.rpm
 rpmbuild \
     -D "_srcrpmdir $PWD/output" \
@@ -32,7 +32,7 @@ rpmbuild \
     -D "_topmdir $PWD/rpmbuild" \
     --rebuild output/*.src.rpm
 
-cd ../rhv-build
+cd $ROOT_PATH/rhv-build/ansible_collections/redhat/rhv
 
 # create tar for automation hub
 ansible-galaxy collection build

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -10,8 +10,8 @@ rm -f ./*tar.gz
 mkdir -p ../ovirt-build ../rhv-build
 # Create builds
 
-./build.sh build ovirt ../ovirt-build
-./build.sh build rhv ../rhv-build
+./build.sh build ovirt $ROOT_PATH/ovirt-build
+./build.sh build rhv $ROOT_PATH/rhv-build
 
 cd $ROOT_PATH/ovirt-build/ansible_collections/ovirt/ovirt/
 # create the src.rpm

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -3,17 +3,18 @@
 ROOT_PATH=$PWD
 
 # remove any previous artifacts
-rm -rf ../ovirt-build ../rhv-build
+rm -rf ../ansible_collections
 rm -f ./*tar.gz
 
-# Create paths for builds
-mkdir -p ../ovirt-build ../rhv-build
 # Create builds
 
-./build.sh build ovirt $ROOT_PATH/ovirt-build
-./build.sh build rhv $ROOT_PATH/rhv-build
+./build.sh build ovirt $ROOT_PATH
+./build.sh build rhv $ROOT_PATH
 
-cd $ROOT_PATH/ovirt-build/ansible_collections/ovirt/ovirt/
+OVIRT_BUILD=$ROOT_PATH/ansible_collections/ovirt/ovirt/
+RHV_BUILD=$ROOT_PATH/ansible_collections/redhat/rhv
+
+cd $OVIRT_BUILD
 # create the src.rpm
 rpmbuild \
     -D "_srcrpmdir $PWD/output" \
@@ -32,7 +33,7 @@ rpmbuild \
     -D "_topmdir $PWD/rpmbuild" \
     --rebuild output/*.src.rpm
 
-cd $ROOT_PATH/rhv-build/ansible_collections/redhat/rhv
+cd $RHV_BUILD
 
 # create tar for automation hub
 ansible-galaxy collection build
@@ -41,14 +42,14 @@ ansible-galaxy collection build
 # archive
 [[ -d exported-artifacts ]] || mkdir -p $ROOT_PATH/exported-artifacts $ROOT_PATH/exported-artifacts/
 
-find ../ovirt-build/output -iname \*rpm -exec mv "{}" $ROOT_PATH/exported-artifacts/ \;
-mv ../ovirt-build/*tar.gz $ROOT_PATH/exported-artifacts/
+find $OVIRT_BUILD/output -iname \*rpm -exec mv "{}" $ROOT_PATH/exported-artifacts/ \;
+mv $OVIRT_BUILD/*tar.gz $ROOT_PATH/exported-artifacts/
 
-mv ../rhv-build/*tar.gz $ROOT_PATH/exported-artifacts/
+mv $RHV_BUILD/*tar.gz $ROOT_PATH/exported-artifacts/
 
 COLLECTION_DIR="/usr/local/share/ansible/collections/ansible_collections/ovirt/ovirt"
 mkdir -p $COLLECTION_DIR
-cp -r ../ovirt-build/* $COLLECTION_DIR
+cp -r $OVIRT_BUILD/* $COLLECTION_DIR
 cd $COLLECTION_DIR
 
 pip3 install rstcheck antsibull-changelog ansible-lint

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ rename() {
 
 build() {
   if [[ $BUILD_PATH ]]; then
-    BUILD_PATH=$BUILD_PATH/ansible_collections/ovirt/ovirt/
+    BUILD_PATH=$BUILD_PATH/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME/
     mkdir -p $BUILD_PATH
     echo "The copying files to $BUILD_PATH"
     cp -r ./* $BUILD_PATH

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,7 @@ rename() {
 
 build() {
   if [[ $BUILD_PATH ]]; then
+    BUILD_PATH=$BUILD_PATH/ansible_collections/ovirt/ovirt/
     mkdir -p $BUILD_PATH
     echo "The copying files to $BUILD_PATH"
     cp -r ./* $BUILD_PATH


### PR DESCRIPTION
maybe it will be better to use the BUILD_PATH as a base path (where all collections should located).
the same as:
    ANSIBLE_COLLECTIONS_PATH

and add the following line to build script: 
    BUILD_PATH=$BUILD_PATH/ansible_collections/ovirt/ovirt/ 
instead of everyone add it in his build command.
the build command will look like:
    ./build.sh build ovirt "$ANSIBLE_COLLECTIONS_PATH"
 
