### PR TITLE
hosted_engine_setup: Allow uppercase characters in the HE-VM MAC address

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-allow-uppercase-in-mac-address.yml
+++ b/changelogs/fragments/hosted_engine_setup-allow-uppercase-in-mac-address.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Allow uppercase characters in mac address (https://github.com/oVirt/ovirt-ansible-collection/pull/150).

--- a/roles/hosted_engine_setup/templates/network-config-dhcp.j2
+++ b/roles/hosted_engine_setup/templates/network-config-dhcp.j2
@@ -2,7 +2,7 @@ version: 1
 config:
   - type: physical
     name: eth0
-    mac_address: "{{ he_vm_mac_addr }}"
+    mac_address: "{{ he_vm_mac_addr|lower }}"
     subnets:
 {% if ipv6_deployment %}
       - type: dhcp6


### PR DESCRIPTION
Change uppercase to lowercase in mac address in order to fit
cloud-init format.
Currently, When using uppercase in mac address cloud-init fails
to change the nic name to eth0 during HE deployment.
This PR should fix it.

Bug-Url: https://bugzilla.redhat.com/1850028
Signed-off-by: Asaf Rachmani <arachman@redhat.com>