### PR TITLE
roles: hosted_engine_setup: Improve engine logs fetching

### DIFF
--- a/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
+++ b/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
@@ -1,0 +1,24 @@
+---
+- name: Add the engine VM as an ansible host
+  block:
+  - name: Fetch the value of HOST_KEY_CHECKING
+    set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
+  - debug: var=host_key_checking
+  - name: Get the username running the deploy
+    become: false
+    command: whoami
+    register: username_on_host
+  - name: Register the engine FQDN as a host
+    add_host:
+      name: "{{ he_fqdn }}"
+      groups: engine
+      ansible_connection: smart
+      ansible_ssh_extra_args: >-
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
+        -o ProxyCommand="ssh -W %h:%p -q
+        {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
+        {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
+      ansible_ssh_pass: "{{ he_appliance_password }}"
+      ansible_user: root
+    no_log: true
+    ignore_errors: true

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -1,26 +1,7 @@
 ---
 - name: Create hosted engine local vm
   block:
-  - name: Fetch the value of HOST_KEY_CHECKING
-    set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
-  - debug: var=host_key_checking
-  - name: Get the username running the deploy
-    become: false
-    command: whoami
-    register: username_on_host
-  - name: Register the engine FQDN as a host
-    add_host:
-      name: "{{ he_fqdn }}"
-      groups: engine
-      ansible_connection: smart
-      ansible_ssh_extra_args: >-
-        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
-        -o ProxyCommand="ssh -W %h:%p -q
-        {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
-      ansible_ssh_pass: "{{ he_appliance_password }}"
-      ansible_user: root
-    no_log: true
+  - import_tasks: add_engine_as_ansible_host.yml
   - name: Initial tasks
     block:
       - name: Get host unique id

--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -1,26 +1,7 @@
 ---
 - name: Create target Hosted Engine VM
   block:
-  - name: Fetch the value of HOST_KEY_CHECKING
-    set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
-  - debug: var=host_key_checking
-  - name: Get the username running the deploy
-    become: false
-    command: whoami
-    register: username_on_host
-  - name: Register the engine FQDN as a host
-    add_host:
-      name: "{{ he_fqdn }}"
-      groups: engine
-      ansible_connection: smart
-      ansible_ssh_extra_args: >-
-        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
-        -o ProxyCommand="ssh -W %h:%p -q
-        {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
-      ansible_ssh_pass: "{{ he_appliance_password }}"
-      ansible_user: root
-    no_log: true
+  - import_tasks: add_engine_as_ansible_host.yml
   - include_tasks: auth_sso.yml
   - name: Get local VM IP
     shell: virsh -r net-dhcp-leases default | grep -i {{ he_vm_mac_addr }} | awk '{ print $5 }' | cut -f1 -d'/'

--- a/roles/hosted_engine_setup/tasks/partial_execution.yml
+++ b/roles/hosted_engine_setup/tasks/partial_execution.yml
@@ -46,19 +46,37 @@
           delegate_to: "{{ groups.engine[0] }}"
 
     - name: Engine Setup on local VM
-      vars:
-        ovirt_engine_setup_hostname: "{{ he_fqdn.split('.')[0] }}"
-        ovirt_engine_setup_organization: "{{ he_cloud_init_domain_name }}"
-        ovirt_engine_setup_dwh_db_host: "{{ he_fqdn.split('.')[0] }}"
-        ovirt_engine_setup_firewall_manager: null
-        ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
-        ovirt_engine_setup_use_remote_answer_file: true
-        ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
-        ovirt_engine_setup_package_list: "{{ he_additional_package_list }}"
-        ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
-      import_role:
-        name: @NAMESPACE@.@NAME@.engine_setup
-      delegate_to: "{{ groups.engine[0] }}"
+      block:
+        - name: Run engine-setup
+          vars:
+            ovirt_engine_setup_hostname: "{{ he_fqdn.split('.')[0] }}"
+            ovirt_engine_setup_organization: "{{ he_cloud_init_domain_name }}"
+            ovirt_engine_setup_dwh_db_host: "{{ he_fqdn.split('.')[0] }}"
+            ovirt_engine_setup_firewall_manager: null
+            ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
+            ovirt_engine_setup_use_remote_answer_file: true
+            ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
+            ovirt_engine_setup_package_list: "{{ he_additional_package_list }}"
+            ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
+          import_role:
+            name: @NAMESPACE@.@NAME@.engine_setup
+          delegate_to: "{{ groups.engine[0] }}"
+      rescue:
+        - name: Sync on engine machine
+          command: sync
+          changed_when: true
+          delegate_to: "{{ groups.engine[0] }}"
+        - name: Fetch logs from the engine VM
+          import_tasks: fetch_engine_logs.yml
+          ignore_errors: true
+          delegate_to: "{{ he_ansible_host_name }}"
+        - name: Notify the user about a failure
+          fail:
+            msg: >
+              There was a failure deploying the engine on the local engine VM.
+              The system may not be provisioned according to the playbook
+              results: please check the logs for the issue,
+              fix accordingly or re-deploy from scratch.
 
     - name: Local engine VM installation - Post tasks
       block:

--- a/roles/hosted_engine_setup/tasks/partial_execution.yml
+++ b/roles/hosted_engine_setup/tasks/partial_execution.yml
@@ -98,6 +98,11 @@
   import_tasks: create_target_vm/03_hosted_engine_final_tasks.yml
   tags: [create_target_vm, never]
 
+- name: Sync on engine machine
+  import_tasks: sync_on_engine_machine.yml
+  changed_when: true
+  ignore_errors: true
+  tags: [create_target_vm, final_clean, never]
 
 - name: Final clean
   import_tasks: final_clean.yml

--- a/roles/hosted_engine_setup/tasks/sync_on_engine_machine.yml
+++ b/roles/hosted_engine_setup/tasks/sync_on_engine_machine.yml
@@ -1,0 +1,9 @@
+---
+- name: Register the engine VM as an ansible host
+  import_tasks: add_engine_as_ansible_host.yml
+- name: Sync on engine machine
+  command: sync
+  changed_when: true
+  ignore_errors: true
+  ignore_unreachable: yes
+  delegate_to: "{{ groups.engine[0] }}"


### PR DESCRIPTION
This is an addition to [1], missing there, updating also
partial_execution.yml . That said:

- This does not (usually?) reproduce on CI, perhaps simply because we
run there with low memory (thus forcing the kernel to sync often)

- I do not know well which parts of this code run on the host, which on
the engine, and what and when adds the engine to the inventory, so not
sure it would always work.

Copying the commit message from [1]:

Sometimes, on failed deploy attempts, engine-logs* directories are
created but left empty. I am guessing that this might be because the
files there are still cached in memory, and we do not fetch from the
engine vm itself (using e.g. ssh) but from the host, directly accessing
the vm disk image. So if, before that, we run 'sync' on the engine vm,
we have better chances to successfully get the logs from the image.

[1] https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/pull/325

Bug-Url: https://bugzilla.redhat.com/1844965