### PR TITLE
add ovirt_repositories_disable_gpg_check to repositories param

### DIFF
--- a/roles/repositories/README.md
+++ b/roles/repositories/README.md
@@ -12,7 +12,7 @@ Role Variables
 |--------------------------------------------|-----------------------|-------------------------------------------|
 | ovirt_repositories_ovirt_release_rpm       | UNDEF                 | URL of oVirt release package, which contains required repositories configuration. |
 | ovirt_repositories_ovirt_release_rpm_gpg   | https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2 | Address of the rpm GPG key. |
-| ovirt_repositories_disable_gpg_check       | False                 | Disable the GPG check. |
+| ovirt_repositories_disable_gpg_check       | False                 | Disable the GPG check for <i>ovirt_repositories_ovirt_release_rpm</i>. by default is False unless 'master.rpm' in <i>ovirt_repositories_ovirt_release_rpm</i>. |
 | ovirt_repositories_use_subscription_manager| False                 | If true it will use repos from subscription manager and the value of <i>ovirt_repositories_ovirt_release_rpm</i> will be ignored. |
 | ovirt_repositories_ovirt_version           | 4.4                   | oVirt release version (Supported versions [4.1, 4.2, 4.3, 4.4]). Will be used to enable the required repositories and enable modules. |
 | ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |

--- a/roles/repositories/README.md
+++ b/roles/repositories/README.md
@@ -12,6 +12,7 @@ Role Variables
 |--------------------------------------------|-----------------------|-------------------------------------------|
 | ovirt_repositories_ovirt_release_rpm       | UNDEF                 | URL of oVirt release package, which contains required repositories configuration. |
 | ovirt_repositories_ovirt_release_rpm_gpg   | https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2 | Address of the rpm GPG key. |
+| ovirt_repositories_disable_gpg_check       | False                 | Disable the GPG check. |
 | ovirt_repositories_use_subscription_manager| False                 | If true it will use repos from subscription manager and the value of <i>ovirt_repositories_ovirt_release_rpm</i> will be ignored. |
 | ovirt_repositories_ovirt_version           | 4.4                   | oVirt release version (Supported versions [4.1, 4.2, 4.3, 4.4]). Will be used to enable the required repositories and enable modules. |
 | ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |

--- a/roles/repositories/defaults/main.yml
+++ b/roles/repositories/defaults/main.yml
@@ -10,4 +10,4 @@ ovirt_repositories_subscription_manager_repos: []
 ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools"]
 ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12"]
 ovirt_repositories_ovirt_release_rpm_gpg: https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2
-ovirt_repositories_disable_gpg_check: False
+ovirt_repositories_disable_gpg_check: "{{ True if 'master.rpm' in ovirt_repositories_ovirt_release_rpm else False }}"

--- a/roles/repositories/defaults/main.yml
+++ b/roles/repositories/defaults/main.yml
@@ -10,3 +10,4 @@ ovirt_repositories_subscription_manager_repos: []
 ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools"]
 ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12"]
 ovirt_repositories_ovirt_release_rpm_gpg: https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2
+ovirt_repositories_disable_gpg_check: False

--- a/roles/repositories/tasks/rpm.yml
+++ b/roles/repositories/tasks/rpm.yml
@@ -3,12 +3,13 @@
   rpm_key:
     state: present
     key: "{{ ovirt_repositories_ovirt_release_rpm_gpg }}"
+  when: not ovirt_repositories_disable_gpg_check
 
 - name: Install oVirt release package
   package:
     name: "{{ ovirt_repositories_ovirt_release_rpm | mandatory }}"
     state: present
-    disable_gpg_check: "{% if 'master.rpm' in ovirt_repositories_ovirt_release_rpm %}True{% else %}False{% endif %}"
+    disable_gpg_check: "{{ ovirt_repositories_disable_gpg_check }}"
 
 - name: Enable dnf modules
   command: "dnf module enable -y {{ ovirt_repositories_ovirt_dnf_modules | join(' ') }}"


### PR DESCRIPTION
disable_gpg_check was limited to the following condition:
if 'master.rpm' in ovirt_repositories_ovirt_release_rpm
