### PR TITLE
Automation: rename ovirt.ovirt to redhat.rhv in all readme.md

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -44,6 +44,11 @@ cd $RHV_BUILD
 # Remove the tarball so it will not be included in automation hub build
 rm -rf *.gz
 
+for file in $(find -name "README.md" -type f)
+do
+sed -i -e "s/ovirt\.ovirt/redhat\.rhv/g" -e "s/ovirt\.ovirt/redhat\.rhv/g" $file
+done
+
 # create tar for automation hub
 ansible-galaxy collection build
 


### PR DESCRIPTION
This fixes the documentation for AH builds before there were READMEs with upstream examples.
And this also keeps GitHub readmes untouched.