### PR TITLE
Inventory plugin: fix timestamp for python2

### DIFF
--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -126,7 +126,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'os_type': vm.os.type,
             'template': self.connection.follow_link(vm.template).name,
             'creation_time': str(vm.creation_time),
-            'creation_time_timestamp': vm.creation_time.strftime("%s.%f"),
+            'creation_time_timestamp': float(vm.creation_time.strftime("%s.%f")),
             'tags': [tag.name for tag in tags],
             'affinity_labels': [label.name for label in labels],
             'affinity_groups': [

--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -126,7 +126,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'os_type': vm.os.type,
             'template': self.connection.follow_link(vm.template).name,
             'creation_time': str(vm.creation_time),
-            'creation_time_timestamp': vm.creation_time.timestamp(),
+            'creation_time_timestamp': vm.creation_time.strftime("%s.%f"),
             'tags': [tag.name for tag in tags],
             'affinity_labels': [label.name for label in labels],
             'affinity_groups': [


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/172

Example of output: 
```
                "creation_time_timestamp": "1598263100.532000",
```
Test on python2:
```python
>>> datetime.datetime.now().strftime("%s.%f")
'1604486628.612790'
```