### PR TITLE
Missing restore task file and vars file

### DIFF
--- a/roles/engine_setup/tasks/restore_engine_from_file.yml
+++ b/roles/engine_setup/tasks/restore_engine_from_file.yml
@@ -1,0 +1,19 @@
+---
+- name: Run engine cleanup command
+  command: "engine-cleanup"
+  when: ovirt_engine_setup_restore_engine_cleanup
+
+- name: Add scopes to restore engine command
+  set_fact:
+    restore_cmd: "{{ restore_cmd }} --scope={{ item }}"
+  with_items: "{{ ovirt_engine_setup_restore_scopes | default([]) }}"
+
+- name: Add restore file and restore options
+  set_fact:
+    restore_cmd: "{{ restore_cmd }} --{{ item.key }}{% if item.value %}={{ item.value }}{% endif %}"
+  with_dict:
+    - file: "{{ ovirt_engine_setup_restore_file }}"
+    - "{{ ovirt_engine_setup_restore_options | default({}) }}"
+
+- name: Run restore engine from backup file
+  command: "{{ restore_cmd }}"

--- a/roles/engine_setup/vars/main.yml
+++ b/roles/engine_setup/vars/main.yml
@@ -1,0 +1,2 @@
+---
+restore_cmd: 'engine-backup --mode=restore'


### PR DESCRIPTION
when running restore flow we failed with the following error:
TASK [ovirt.ovirt.engine_setup : Restore engine from file] *********************
fatal: [example.com]: FAILED! => {"reason": "Could not find or access
'/path/to/file/restore_engine_from_file.yml' on the Ansible Controller."}

