### PR TITLE
roles: hosted_engine_setup: Add after_add_host hook

### DIFF
--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -343,8 +343,13 @@ during the deployment process. There are 2 ways to do that:
 
 Write ansible playbooks that will run on the engine VM before or after the engine VM installation.
 
-Add the playbooks that will run __before__ the engine setup to
-```hooks/enginevm_before_engine_setup``` and the playbooks that will run __after__ the engine setup to ```hooks/enginevm_after_engine_setup```.
+You can add the playbooks to the following locations:
+
+- ```hooks/enginevm_before_engine_setup```: These will be ran before running engine-setup on the engine machine.
+
+- ```hooks/enginevm_after_engine_setup```: These will be ran after running engine-setup on the engine machine.
+
+- ```hooks/after_add_host```: These will be ran after adding the host to the engine, but before checking if it is up. You can place here playbooks to customize the host, such as configuring required networks, and then activate it, so that deployment will find it as "Up" and continue successfully.
 
 These playbooks will be consumed automatically by the role when you execute it.
 

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -350,7 +350,7 @@ You can add the playbooks to the following locations:
 
 - ```hooks/enginevm_after_engine_setup```: These will be ran after running engine-setup on the engine machine.
 
-- ```hooks/after_add_host```: These will be ran after adding the host to the engine, but before checking if it is up. You can place here playbooks to customize the host, such as configuring required networks, and then activate it, so that deployment will find it as "Up" and continue successfully.
+- ```hooks/after_add_host```: These will be ran after adding the host to the engine, but before checking if it is up. You can place here playbooks to customize the host, such as configuring required networks, and then activate it, so that deployment will find it as "Up" and continue successfully. See examples/required_networks_fix.yml for an example.
 
 These playbooks will be consumed automatically by the role when you execute it.
 

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -41,6 +41,7 @@ Ansible role for deploying oVirt Hosted-Engine
 | he_tcp_t_address | null | hostname to connect if he_network_test is *tcp*  |
 | he_tcp_t_port | null | port to connect if he_network_test is *tcp* |
 | he_pause_host | false | Pause the execution to let the user interactively fix host configuration |
+| he_pause_after_failed_add_host | true | Pause the execution if Add Host failed with status non_operational, to let the user interactively fix host configuration |
 | he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 | he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
 | he_debug_mode | false | If `True`, HE deployment will execute additional tasks for debug |
@@ -360,6 +361,10 @@ To make manual adjustments you can set the variable ```he_pause_host``` to true.
 In order to proceed with the deployment, before deleting the lock-file, make sure that the host is on 'up' state at the engine's URL.
 
 Both of the lock-file path and the engine's URL will be presented during the role execution.
+
+**On Failure**
+
+If "Add Host" failed and left the host in status "non_operational", by default the deployment will be paused, similarly to "Manual" above, so that the user can try to fix the host to get it to "up" state, before removing the lock file and continuing. If you want the process to fail instead of pausing, set `he_pause_after_failed_add_host` to false.
 
 Demo
 ----

--- a/roles/hosted_engine_setup/defaults/main.yml
+++ b/roles/hosted_engine_setup/defaults/main.yml
@@ -49,6 +49,7 @@ he_force_ip4: false
 he_force_ip6: false
 
 he_pause_host: false
+he_pause_after_failed_add_host: true
 he_debug_mode: false
 
 ## Mandatory variables:

--- a/roles/hosted_engine_setup/examples/required_networks_fix.yml
+++ b/roles/hosted_engine_setup/examples/required_networks_fix.yml
@@ -1,0 +1,56 @@
+---
+# This is an example for a hook to fix restore-from-file errors
+# due to missing required networks.
+#
+# If you have an existing hosted-engine setup, and the Default cluster
+# has some required network, then if you take a backup and try to restore
+# it with '--restore-from-file', the deployment process cannot know which
+# host nic should be attached to the required network, and so activating
+# the host will fail. This will prompt the user to manually handle the
+# situation via the engine web admin UI.
+#
+# If you already know that beforehand, and want to automate restoration,
+# you can copy current file, edit as needed, and place it in:
+# /usr/share/ansible/collections/ansible_collections/ovirt/ovirt/roles/hosted_engine_setup/hooks/after_add_host/
+# File name should end with '.yml'.
+#
+# For more details, see (also):
+# https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_network_module.html
+# https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_module.html
+
+- include_tasks: auth_sso.yml
+
+- name: Wait for the host to be up
+  ovirt_host_info:
+    pattern: name=myhost
+    auth: "{{ ovirt_auth }}"
+  register: host_result_up_check
+  until: >-
+    host_result_up_check is succeeded and
+    host_result_up_check.ovirt_hosts|length >= 1 and
+    (
+    host_result_up_check.ovirt_hosts[0].status == 'up' or
+    host_result_up_check.ovirt_hosts[0].status == 'non_operational'
+    )
+  retries: 120
+  delay: 10
+  ignore_errors: true
+
+- name: Handle non_operational myhost
+  block:
+  - name: Attach interface eth0 on host myhost to network net1
+    ovirt.ovirt.ovirt_host_network:
+      auth: "{{ ovirt_auth }}"
+      name: myhost
+      interface: eth0
+      networks:
+        - name: net1
+  - name: Activate host myhost
+    ovirt.ovirt.ovirt_host:
+      auth: "{{ ovirt_auth }}"
+      name: myhost
+      state: present
+  when: >-
+    host_result_up_check is succeeded and
+    host_result_up_check.ovirt_hosts|length >= 1 and
+    host_result_up_check.ovirt_hosts[0].status == 'non_operational'

--- a/roles/hosted_engine_setup/hooks/after_add_host/README.md
+++ b/roles/hosted_engine_setup/hooks/after_add_host/README.md
@@ -1,0 +1,3 @@
+# USAGE
+
+Place here playbooks to be executed after trying to add the host to the engine.

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -123,6 +123,11 @@
       auth: "{{ ovirt_auth }}"
     async: 1
     poll: 0
+  - name: Include after_add_host tasks files
+    include_tasks: "{{ item }}"
+    with_fileglob: "hooks/after_add_host/*.yml"
+    register: include_after_add_host_results
+  - debug: var=include_after_add_host_results
   - name: Pause the execution to let the user interactively reconfigure the host
     block:
       - name: Let the user connect to the bootstrap engine to manually fix host configuration

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -161,6 +161,69 @@
       msg: >-
         Host is not up, please check logs, perhaps also on the engine machine
     when: host_result_up_check is failed
+
+  - name: Emit error messages about the failure
+    block:
+      - set_fact: host_id={{ host_result_up_check.ovirt_hosts[0].id }}
+      - name: Collect error events from the Engine
+        ovirt_event_info:
+          auth: "{{ ovirt_auth }}"
+          search: "severity>=warning"
+        register: error_events
+
+      - name: Generate the error message from the engine events
+        set_fact:
+          error_description: >-
+            {% for event in error_events.ovirt_events | groupby('code') %}
+            {% if event[1][0].host.id == host_id %}
+            code {{ event[0] }}: {{ event[1][0].description }},
+            {% endif %}
+            {% endfor %}
+        ignore_errors: true
+
+      - name: Notify with error description
+        debug:
+          msg: >-
+            The host has been set in non_operational status,
+            deployment errors: {{ error_description }}
+        when: error_description is defined
+
+      - name: Notify with generic error
+        debug:
+          msg: >-
+            The host has been set in non_operational status,
+            please check engine logs,
+            more info can be found in the engine logs.
+        when: error_description is not defined
+    when: >-
+      host_result_up_check is succeeded and
+      host_result_up_check.ovirt_hosts|length >= 1 and
+      host_result_up_check.ovirt_hosts[0].status == 'non_operational'
+
+  - name: Pause the execution to let the user interactively reconfigure the host
+    block:
+      - name: Let the user connect to the bootstrap engine to manually fix host configuration
+        debug:
+          msg: >-
+            You can now connect to {{ bootstrap_engine_url }} and check the status of this host and
+            eventually remediate it, please continue only when the host is listed as 'up'
+      - include_tasks: pause_execution.yml
+    when: >-
+      he_pause_after_failed_add_host|bool and
+      host_result_up_check is succeeded and
+      host_result_up_check.ovirt_hosts|length >= 1 and
+      host_result_up_check.ovirt_hosts[0].status == 'non_operational'
+
+  # refresh the auth token after a long operation to avoid having it expired
+  - include_tasks: auth_revoke.yml
+  - include_tasks: auth_sso.yml
+  - name: Check if the host is up
+    ovirt_host_info:
+      pattern: name={{ he_host_name }}
+      auth: "{{ ovirt_auth }}"
+    register: host_result_up_check
+    ignore_errors: true
+
   - name: Handle deployment failure
     block:
       - set_fact: host_id={{ host_result_up_check.ovirt_hosts[0].id }}

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -167,7 +167,7 @@
       - name: Collect error events from the Engine
         ovirt_event_info:
           auth: "{{ ovirt_auth }}"
-          search: "severity>=error"
+          search: "severity>=warning"
         register: error_events
 
       - name: Generate the error message from the engine events

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -175,7 +175,7 @@
         set_fact:
           error_description: >-
             {% for event in error_events.ovirt_events | groupby('code') %}
-            {% if event[1][0].host.id == host_id %}
+            {% if 'host' in event[1][0] and 'id' in event[1][0].host and event[1][0].host.id == host_id %}
             code {{ event[0] }}: {{ event[1][0].description }},
             {% endif %}
             {% endfor %}

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -366,7 +366,7 @@
         fail:
           msg: The engine failed to start inside the engine VM; please check engine.log.
   - name: Get target engine VM address
-    shell: getent {{ ip_key }} {{ he_fqdn }} | cut -d' ' -f1 | uniq
+    shell: getent {{ ip_key }} {{ he_fqdn }} | cut -d ' ' -f1 | uniq
     environment: "{{ he_cmd_lang }}"
     register: engine_vm_ip
     when: engine_vm_ip is not defined

--- a/roles/hosted_engine_setup/tasks/filter_team_devices.yml
+++ b/roles/hosted_engine_setup/tasks/filter_team_devices.yml
@@ -27,7 +27,7 @@
     otopi_host_net: "{{ host_net | difference(team_if) }}"
   register: otopi_host_net
 - debug: var=otopi_host_net
-- name: Failed if only teaming devices are availible
+- name: Failed if only teaming devices are available
   fail:
     msg: >-
       Only Team devices {{ team_if | join(', ') }} are present.


### PR DESCRIPTION
Allow running custom playbooks after trying to add the host to the
engine.

Bug-Url: https://bugzilla.redhat.com/1893385