### PR TITLE
correct name of os_type

### DIFF
--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -123,7 +123,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'status': str(vm.status),
             'description': vm.description,
             'fqdn': vm.fqdn,
-            'os_type': vm.os.type,
+            'os': vm.os.type,
             'template': self.connection.follow_link(vm.template).name,
             'creation_time': str(vm.creation_time),
             'creation_time_timestamp': float(vm.creation_time.strftime("%s.%f")),


### PR DESCRIPTION
Fixes https://github.com/oVirt/ovirt-ansible-collection/issues/193

The return of the inventory has os_type inside even if we don't use the variable in search.
This breaks bp not sure if we should implement it. 