### PR TITLE
ovirt_host_network: fix bond modes

### DIFF
--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -242,15 +242,6 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
 
 
 def get_bond_options(mode, usr_opts):
-    MIIMON_100 = dict(miimon='100')
-    DEFAULT_MODE_OPTS = {
-        '0': MIIMON_100,
-        '1': MIIMON_100,
-        '2': MIIMON_100,
-        '3': MIIMON_100,
-        '4': dict(xmit_hash_policy='2')
-    }
-
     options = []
     if mode is None:
         return options
@@ -284,8 +275,12 @@ def get_bond_options(mode, usr_opts):
             value=str(mode_number)
         )
     )
+    opts_dict = {}
+    if mode == 4:
+        opts_dict = dict(xmit_hash_policy='2')
+    elif mode < 4:
+        opts_dict = dict(miimon='100')
 
-    opts_dict = DEFAULT_MODE_OPTS.get(str(mode), {})
     if usr_opts is not None:
         opts_dict.update(**usr_opts)
 

--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -244,10 +244,11 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
 def get_bond_options(mode, usr_opts):
     MIIMON_100 = dict(miimon='100')
     DEFAULT_MODE_OPTS = {
+        '0': MIIMON_100,
         '1': MIIMON_100,
         '2': MIIMON_100,
         '3': MIIMON_100,
-        '4': dict(xmit_hash_policy='2', **MIIMON_100)
+        '4': dict(xmit_hash_policy='2')
     }
 
     options = []
@@ -264,6 +265,8 @@ def get_bond_options(mode, usr_opts):
             'Load balance (balance-xor)',
             None,
             'Dynamic link aggregation (802.3ad)',
+            'Adaptive transmit load balancing (balance-tlb)',
+            None,
         ]
         if (not 0 < mode_number <= len(modes)):
             return None


### PR DESCRIPTION
When rerunning the same playbook there was an issue of redeployment of the same network.
It was caused by a missing config in getting the bond options so the check update function was not returning correct value. 
