### PR TITLE
roles: hosted_engine_setup: Collect all engine /var/log

### DIFF
--- a/roles/hosted_engine_setup/tasks/fetch_engine_logs.yml
+++ b/roles/hosted_engine_setup/tasks/fetch_engine_logs.yml
@@ -25,6 +25,5 @@
   ignore_errors: true
   changed_when: true
   with_items:
-    - /var/log/ovirt-engine
-    - /var/log/messages
+    - /var/log
   when: local_vm_disk_path is defined


### PR DESCRIPTION
In the code collecting stuff from the engine machine, we collect only
/var/log/messages and /var/log/ovirt-engine.

Change this to collect all of /var/log.

I think this is useful in general, and does not add too much waste (in
deploy time and space after that).

For now, I am pushing this to try to debug:
https://bugzilla.redhat.com/1915329