### PR TITLE
Add ovirt_system_option_info

### DIFF
--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -24,15 +24,15 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: ovirt_system_options_info
-short_description: Retrieve information about one oVirt/RHV system option.
+module: ovirt_system_option_info
+short_description: Retrieve information about one oVirt/RHV system options.
 version_added: "1.3.0"
 author: "Martin Necas (@mnecas)"
 description:
     - "Retrieve information about one or more oVirt/RHV system options."
 notes:
-    - "This module returns a variable C(ovirt_system_options_info), which
-       contains a list of system options. You need to register the result with
+    - "This module returns a variable C(ovirt_system_option_info), which
+       contains a list of system option. You need to register the result with
        the I(register) keyword to use it."
 options:
     name:
@@ -50,16 +50,16 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-- @NAMESPACE@.@NAME@.ovirt_system_options_info:
+- @NAMESPACE@.@NAME@.ovirt_system_option_info:
     name: "ServerCPUList"
     version: "4.4"
   register: result
 - ansible.builtin.debug:
-    msg: "{{ result.ovirt_system_options }}"
+    msg: "{{ result.ovirt_system_option }}"
 '''
 
 RETURN = '''
-ovirt_system_options:
+ovirt_system_option:
     description: "Dictionary describing the system option. Option attributes are mapped to dictionary keys,
                   all option attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/system_option."
     returned: On success.
@@ -99,7 +99,7 @@ def main():
             raise Exception("Unexpected error: '{}'".format(e))
 
         result = dict(
-            ovirt_system_options = get_dict_of_struct(
+            ovirt_system_option = get_dict_of_struct(
                 struct=option,
                 connection=connection,
                 fetch_nested=module.params.get('fetch_nested'),

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -89,7 +89,6 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         options_service = connection.system_service().options_service()
-        raise Exception(options_service.list())
         option_service = options_service.option_service(module.params.get('name'))
 
         try:

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -29,15 +29,15 @@ short_description: Retrieve information about one oVirt/RHV system options.
 version_added: "1.3.0"
 author: "Martin Necas (@mnecas)"
 description:
-    - "Retrieve information about one or more oVirt/RHV system options."
+    - "Retrieve information about one oVirt/RHV system options."
 notes:
     - "This module returns a variable C(ovirt_system_option_info), which
-       contains a list of system option. You need to register the result with
+       contains a dict of system option. You need to register the result with
        the I(register) keyword to use it."
 options:
     name:
         description:
-            - "Name of system option profile."
+            - "Name of system option."
         type: str
     version:
         description:
@@ -63,7 +63,7 @@ ovirt_system_option:
     description: "Dictionary describing the system option. Option attributes are mapped to dictionary keys,
                   all option attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/system_option."
     returned: On success.
-    type: list
+    type: dict
 '''
 
 import traceback

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -89,17 +89,18 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         options_service = connection.system_service().options_service()
+        raise Exception(options_service.list())
         option_service = options_service.option_service(module.params.get('name'))
 
         try:
             option = option_service.get(version=module.params.get('version'))
         except Exception as e:
             if str(e) == "HTTP response code is 404.":
-                raise ValueError("Could not find the option with name '{}'".format(module.params.get('name')))
-            raise Exception("Unexpected error: '{}'".format(e))
+                raise ValueError("Could not find the option with name '{0}'".format(module.params.get('name')))
+            raise Exception("Unexpected error: '{0}'".format(e))
 
         result = dict(
-            ovirt_system_option = get_dict_of_struct(
+            ovirt_system_option=get_dict_of_struct(
                 struct=option,
                 connection=connection,
                 fetch_nested=module.params.get('fetch_nested'),


### PR DESCRIPTION
Fixes https://github.com/oVirt/ovirt-ansible-collection/issues/204

- Add new module ovirt_system_option_info to gather information about the system options.
- We cannot list the options so there are some parameters that will not be used like fetch_nested and nested_attributes. The reason why I kept it there is that I would need to 
  - either create another doc fragment for this specific module and don't use the info fragment
  - or move all necessary arguments to this module but this could break something if we would change the main and we could forget about this

Example input:
```yaml
      ovirt.ovirt.ovirt_system_option_info:
        auth: "{{ ovirt_auth }}"
        name: ServerCPUList
        version: "4.4"
```
Example output: 
```json
    "ovirt_system_option": {
        "href": "/ovirt-engine/api/options/ServerCPUList",
        "id": "ServerCPUList",
        "name": "ServerCPUList",
        "values": [
            {
                "value": "1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; 2:Secure Intel ...",
                "version": "4.4"
            }
        ]
    }
```