### PR TITLE
roles: hosted_engine_setup: Use headers authorization

### DIFF
--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -53,13 +53,12 @@
         {{ cluster_version.major }}.{{ cluster_version.minor }}"
       validate_certs: false
       force_basic_auth: true
-      user: admin@internal
-      password: "{{ he_admin_password }}"
       method: GET
       return_content: true
       status_code: 200
       headers:
         Accept: application/json
+        Authorization: "Basic {{ ('admin@internal' + ':' +  he_admin_password ) | b64encode }}"
     no_log: true
     register: server_cpu_list
   - debug: var=server_cpu_list


### PR DESCRIPTION
Use headers authorization instead of user and password parameters
of the module.

Bug-Url: https://bugzilla.redhat.com/1915286
Signed-off-by: Asaf Rachmani <arachman@redhat.com>