### PR TITLE
Spec auth options

### DIFF
--- a/changelogs/fragments/auth_dict.yml
+++ b/changelogs/fragments/auth_dict.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Set ``auth`` options into argument spec definition so Ansible will validate the user options
+- Set ``no_log`` on ``password`` and ``token`` in the ``auth`` dict so the values are exposed in the invocation log

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -374,7 +374,7 @@ def wait(
 def __get_auth_dict():
     return dict(
         type='dict',
-        required=True,
+        apply_defaults=True,
         options=dict(
             url=dict(
                 type='str',
@@ -383,7 +383,7 @@ def __get_auth_dict():
             hostname=dict(
                 type='str',
                 fallback=(env_fallback, ['OVIRT_HOSTNAME']),
-            )
+            ),
             username=dict(
                 type='str',
                 fallback=(env_fallback, ['OVIRT_USERNAME']),

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -375,6 +375,7 @@ def __get_auth_dict():
     return dict(
         type='dict',
         apply_defaults=True,
+        required_one_of=[['hostname', 'url']],
         options=dict(
             url=dict(
                 type='str',


### PR DESCRIPTION
Currently the `auth` option is a free form dict with some env fallback options. This is problematic because there is no validation happening on the user input leading to bad UX when dealing with typos or just understanding what options are available when running with `-vvv`. It will also expose the value of `password` and `token` if they are defined as an Ansible option which is not a good thing. This PR defines the `auth` sub options as part of the argument spec so `basic.py` validates the options and it still includes the env var fallbacks if not explicitly set in the task.

This should be backported to Ansible 2.9 if possible.

Fixes https://github.com/oVirt/ovirt-ansible-collection/issues/198