### PR TITLE
ovirt_host_storage_info: no need for login to get info

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -457,14 +457,6 @@ def transfer(connection, module, direction, transfer_func):
     finally:
         transfer_service.finalize()
 
-        disks_service = connection.system_service().disks_service()
-        wait(
-            service=disks_service.service(module.params['id']),
-            condition=lambda d: d.status == otypes.DiskStatus.OK,
-            wait=module.params['wait'],
-            timeout=module.params['timeout'],
-        )
-
         while transfer.phase in [
             otypes.ImageTransferPhase.TRANSFERRING,
             otypes.ImageTransferPhase.FINALIZING_SUCCESS,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -456,7 +456,6 @@ def transfer(connection, module, direction, transfer_func):
         return True
     finally:
         transfer_service.finalize()
-
         while transfer.phase in [
             otypes.ImageTransferPhase.TRANSFERRING,
             otypes.ImageTransferPhase.FINALIZING_SUCCESS,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -456,6 +456,15 @@ def transfer(connection, module, direction, transfer_func):
         return True
     finally:
         transfer_service.finalize()
+
+        disks_service = connection.system_service().disks_service()
+        wait(
+            service=disks_service.service(module.params['id']),
+            condition=lambda d: d.status == otypes.DiskStatus.OK,
+            wait=module.params['wait'],
+            timeout=module.params['timeout'],
+        )
+
         while transfer.phase in [
             otypes.ImageTransferPhase.TRANSFERRING,
             otypes.ImageTransferPhase.FINALIZING_SUCCESS,

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -136,16 +136,12 @@ def main():
 
         # Get LUNs exposed from the specified target
         host_storages = host_service.storage_service().list()
-        filterred_host_storages = [host_storage for host_storage in host_storages]
         if module.params.get('iscsi') is not None:
-            filterred_host_storages = [host_storage for host_storage in host_storages
-                                       if host_storage.type == otypes.StorageType.ISCSI]
+            host_storages = list(filter(lambda x: x.type == otypes.StorageType.ISCSI, host_storages))
             if 'target' in module.params.get('iscsi'):
-                filterred_host_storages = [host_storage for host_storage in filterred_host_storages
-                                           if module.params.get('iscsi').get('target') == host_storage.logical_units[0].target]
+                host_storages = list(filter(lambda x: module.params.get('iscsi').get('target') == x.logical_units[0].target, host_storages))
         elif module.params.get('fcp') is not None:
-            filterred_host_storages = [host_storage for host_storage in host_storages
-                                       if host_storage.type == otypes.StorageType.FCP]
+            host_storages = list(filter(lambda x: x.type == otypes.StorageType.FCP, host_storages))
 
         result = dict(
             ovirt_host_storages=[
@@ -154,7 +150,7 @@ def main():
                     connection=connection,
                     fetch_nested=module.params.get('fetch_nested'),
                     attributes=module.params.get('nested_attributes'),
-                ) for c in filterred_host_storages
+                ) for c in host_storages
             ],
         )
         module.exit_json(changed=False, **result)

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -142,7 +142,7 @@ def main():
                                        if host_storage.type == otypes.StorageType.ISCSI]
             if 'target' in module.params.get('iscsi'):
                 filterred_host_storages = [host_storage for host_storage in filterred_host_storages
-                                           if iscsi.get('target') == host_storage.logical_units[0].target]
+                                           if module.params.get('iscsi').get('target') == host_storage.logical_units[0].target]
         elif module.params.get('fcp') is not None:
             filterred_host_storages = [host_storage for host_storage in host_storages
                                        if host_storage.type == otypes.StorageType.FCP]

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -140,18 +140,19 @@ def main():
         if storage_type == 'iscsi':
             # Login
             iscsi = module.params.get('iscsi')
-            _login(host_service, iscsi)
+            if iscsi:
+                _login(host_service, iscsi)
 
         # Get LUNs exposed from the specified target
         host_storages = host_service.storage_service().list()
-
-        if storage_type == 'iscsi':
+        filterred_host_storages = [host_storage for host_storage in host_storages]
+        if module.params.get('iscsi') and storage_type == 'iscsi':
             filterred_host_storages = [host_storage for host_storage in host_storages
                                        if host_storage.type == otypes.StorageType.ISCSI]
             if 'target' in iscsi:
                 filterred_host_storages = [host_storage for host_storage in filterred_host_storages
                                            if iscsi.get('target') == host_storage.logical_units[0].target]
-        elif storage_type == 'fcp':
+        elif module.params.get('fcp') and storage_type == 'fcp':
             filterred_host_storages = [host_storage for host_storage in host_storages
                                        if host_storage.type == otypes.StorageType.FCP]
 

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -73,6 +73,20 @@ EXAMPLES = '''
   register: result
 - ansible.builtin.debug:
     msg: "{{ result.ovirt_host_storages }}"
+
+- name: Gather information about all storages
+  @NAMESPACE@.@NAME@.ovirt_host_storage_info:
+    host: myhost
+
+- name: Gather information about all iscsi storages
+  @NAMESPACE@.@NAME@.ovirt_host_storage_info:
+    host: myhost
+    iscsi: {}
+
+- name: Gather information about all fcp storages
+  @NAMESPACE@.@NAME@.ovirt_host_storage_info:
+    host: myhost
+    fcp: {}
 '''
 
 RETURN = '''

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -146,13 +146,13 @@ def main():
         # Get LUNs exposed from the specified target
         host_storages = host_service.storage_service().list()
         filterred_host_storages = [host_storage for host_storage in host_storages]
-        if module.params.get('iscsi') and storage_type == 'iscsi':
+        if storage_type == 'iscsi':
             filterred_host_storages = [host_storage for host_storage in host_storages
                                        if host_storage.type == otypes.StorageType.ISCSI]
             if 'target' in iscsi:
                 filterred_host_storages = [host_storage for host_storage in filterred_host_storages
                                            if iscsi.get('target') == host_storage.logical_units[0].target]
-        elif module.params.get('fcp') and storage_type == 'fcp':
+        elif storage_type == 'fcp':
             filterred_host_storages = [host_storage for host_storage in host_storages
                                        if host_storage.type == otypes.StorageType.FCP]
 


### PR DESCRIPTION
We don't need to login to iscsi before getting all information about the host storages.
Now user can only select the host from which to get the storages and filter if iscsi or fcp.

**Examples:** 
To get all storage from host:
```
    - ovirt.ovirt.ovirt_host_storage_info:
        host: host_mixed_1
        auth: "{{ ovirt_auth }}"
```
To get only iscsi storages: 
```
    - ovirt.ovirt.ovirt_host_storage_info:
        host: host_mixed_1
        iscsi: {}
        auth: "{{ ovirt_auth }}"
```

