### PR TITLE
ovirt_disk: fix transfer ending

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -370,6 +370,7 @@ from ansible.module_utils.six.moves.http_client import HTTPSConnection, Incomple
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 try:
     import ovirtsdk4.types as otypes
+    import ovirtsdk4
 except ImportError:
     pass
 from ansible.module_utils.basic import AnsibleModule
@@ -464,7 +465,7 @@ def transfer(connection, module, direction, transfer_func):
             time.sleep(module.params['poll_interval'])
             try:
                 transfer = transfer_service.get()
-            except Exception:
+            except ovirtsdk4.NotFoundError:
                 break
         if transfer.phase in [
             otypes.ImageTransferPhase.UNKNOWN,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -459,9 +459,14 @@ def transfer(connection, module, direction, transfer_func):
         while transfer.phase in [
             otypes.ImageTransferPhase.TRANSFERRING,
             otypes.ImageTransferPhase.FINALIZING_SUCCESS,
+            otypes.ImageTransferPhase.FINISHED_SUCCESS
         ]:
             time.sleep(module.params['poll_interval'])
-            transfer = transfer_service.get()
+
+            try:
+                transfer = transfer_service.get()
+            except Exception:
+                break
         if transfer.phase in [
             otypes.ImageTransferPhase.UNKNOWN,
             otypes.ImageTransferPhase.FINISHED_FAILURE,

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -462,7 +462,6 @@ def transfer(connection, module, direction, transfer_func):
             otypes.ImageTransferPhase.FINISHED_SUCCESS
         ]:
             time.sleep(module.params['poll_interval'])
-
             try:
                 transfer = transfer_service.get()
             except Exception:


### PR DESCRIPTION
Issue: after uploading the image the status of the disk was OK so it tried to attach the disk to the VM but at that moment it failed because of the unfinished transfer status.

Now we wait longer after the transfer is done and it is removed.

I think it would be best to fix this in the SDK and this could be just a temporary fix.
