### PR TITLE
ovirt_auth: fix env auth dict

### DIFF
--- a/plugins/doc_fragments/ovirt.py
+++ b/plugins/doc_fragments/ovirt.py
@@ -81,6 +81,16 @@ options:
                 description:
                     - Dictionary of HTTP headers to be added to each API call.
                 type: dict
+            timeout:
+                description: Number of seconds to wait for response.
+                returned: success
+                type: int
+                sample: 0
+            compress:
+                description: Flag indicating if compression is used for connection.
+                returned: success
+                type: bool
+                sample: True
         type: dict
         required: true
     timeout:

--- a/plugins/doc_fragments/ovirt.py
+++ b/plugins/doc_fragments/ovirt.py
@@ -83,14 +83,10 @@ options:
                 type: dict
             timeout:
                 description: Number of seconds to wait for response.
-                returned: success
                 type: int
-                sample: 0
             compress:
                 description: Flag indicating if compression is used for connection.
-                returned: success
                 type: bool
-                sample: True
         type: dict
         required: true
     timeout:

--- a/plugins/doc_fragments/ovirt.py
+++ b/plugins/doc_fragments/ovirt.py
@@ -87,6 +87,7 @@ options:
             compress:
                 description: Flag indicating if compression is used for connection.
                 type: bool
+                default: true
         type: dict
         required: true
     timeout:

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -77,6 +77,16 @@ options:
                 description:
                     - Dictionary of HTTP headers to be added to each API call.
                 type: dict
+            timeout:
+                description: Number of seconds to wait for response.
+                returned: success
+                type: int
+                sample: 0
+            compress:
+                description: Flag indicating if compression is used for connection.
+                returned: success
+                type: bool
+                sample: True
         type: dict
         required: true
 requirements:

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -79,14 +79,10 @@ options:
                 type: dict
             timeout:
                 description: Number of seconds to wait for response.
-                returned: success
                 type: int
-                sample: 0
             compress:
                 description: Flag indicating if compression is used for connection.
-                returned: success
                 type: bool
-                sample: True
         type: dict
         required: true
 requirements:

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -83,6 +83,7 @@ options:
             compress:
                 description: Flag indicating if compression is used for connection.
                 type: bool
+                default: true
         type: dict
         required: true
 requirements:

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -407,6 +407,18 @@ def __get_auth_dict():
                 type='str',
                 fallback=(env_fallback, ['OVIRT_CAFILE']),
             ),
+            compress=dict(
+                type='bool',
+                default=True
+            ),
+            timeout=dict(
+                type='int',
+                default=0
+            ),
+            ovirt_auth=dict(
+                required=False,
+                type='dict'
+            ),
             kerberos=dict(type='bool'),
             headers=dict(type='dict')
         )

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -415,10 +415,6 @@ def __get_auth_dict():
                 type='int',
                 default=0
             ),
-            ovirt_auth=dict(
-                required=False,
-                type='dict'
-            ),
             kerberos=dict(type='bool'),
             headers=dict(type='dict')
         )


### PR DESCRIPTION
Follow up of https://github.com/oVirt/ovirt-ansible-collection/pull/211
The issue was that the `ovirt_auth` module was returning and passing `timeout` and `compress` to other modules with the `auth` option. But they were not mentioned in the updated code which forces to match the `auth` before the #211 the options were ignored. 
@mwperina @didib 
