### PR TITLE
role: hosted_engine_setup: Filter devices with unsupported bond mode

### DIFF
--- a/roles/hosted_engine_setup/tasks/filter_unsupported_devices.yml
+++ b/roles/hosted_engine_setup/tasks/filter_unsupported_devices.yml
@@ -22,14 +22,16 @@
   set_fact:
     team_if: "{{  team_list.results | reject('skipped') | map(attribute='nic_if.nic') | list }}"
 - debug: var=team_if
+- import_tasks: filter_unsupported_vlan_devices.yml
 - name: Filter unsupported interface types
   set_fact:
-    otopi_host_net: "{{ host_net | difference(team_if) }}"
+    otopi_host_net: "{{ host_net | difference(invalid_net_if) }}"
   register: otopi_host_net
 - debug: var=otopi_host_net
-- name: Failed if only teaming devices are available
+- name: Failed if only unsupported devices are available
   fail:
     msg: >-
-      Only Team devices {{ team_if | join(', ') }} are present.
-      Teaming is not supported.
+      Only unsupported devices {{ invalid_net_if | join(', ') }} are present.
+      Teaming and bond modes: Round Robin, TLB, ALB are unsupported.
+      The following bond modes are supported: {{ acceptable_bond_modes }}
   when: (otopi_host_net.ansible_facts.otopi_host_net | length == 0)

--- a/roles/hosted_engine_setup/tasks/filter_unsupported_vlan_devices.yml
+++ b/roles/hosted_engine_setup/tasks/filter_unsupported_vlan_devices.yml
@@ -1,0 +1,67 @@
+---
+- name: Check for VLAN devices
+  set_fact:
+    is_vlan: "{{ nic_if.stdout == 'vlan' }}"
+  when: nic_if.stdout.find('vlan') != -1
+  with_items:
+    - "{{ interface_types.results }}"
+  loop_control:
+    loop_var: nic_if
+  register: vlan_list
+- debug: var=vlan_list
+- name: Check for base interface of VLAN devices
+  command: nmcli -g VLAN.PARENT device show {{ vlan_device.nic_if.nic }}
+  when: vlan_device.ansible_facts is defined and vlan_device.ansible_facts.is_vlan
+  with_items:
+    - "{{ vlan_list.results | reject('skipped') | list }}"
+  loop_control:
+    loop_var: vlan_device
+  register: vlan_base_interfaces
+- debug: var=vlan_base_interfaces
+- name: Get base interface types of VLAN devices
+  command: nmcli -g GENERAL.TYPE device show {{ vlan_base_interface.stdout }}
+  when: vlan_base_interface.skipped is undefined and vlan_base_interface.stdout is defined
+  with_items:
+    - "{{ vlan_base_interfaces.results }}"
+  loop_control:
+    loop_var: vlan_base_interface
+  register: vlan_base_types
+- debug: var=vlan_base_types
+- name: Check for bond as base type of VLAN device
+  set_fact:
+    bond_parent: "{{ vlan_base_type.vlan_base_interface.stdout }}"
+  when: vlan_base_type.skipped is undefined and vlan_base_type.stdout is defined and vlan_base_type.stdout == "bond"
+  with_items:
+    - "{{ vlan_base_types.results | reject('skipped') | list }}"
+  loop_control:
+    loop_var: vlan_base_type
+  register: vlan_bond_list
+- debug: var=vlan_bond_list
+- name: Check if bond base interface of VLAN device is in supported mode
+  set_fact:
+    bond_parent_mode: "{{ hostvars[inventory_hostname]['ansible_' + vlan_bond_device.ansible_facts.bond_parent]['mode'] }}"
+    vlan_bond_valid_if: "{{ vlan_bond_device.vlan_base_type.vlan_base_interface.vlan_device.nic_if.nic }}"
+    is_valid_bond_mode: "{{ hostvars[inventory_hostname]['ansible_' + vlan_bond_device.ansible_facts.bond_parent]['mode'] in acceptable_bond_modes }}"
+  with_items: "{{ vlan_bond_list.results | reject('skipped') | list }}"
+  loop_control:
+    loop_var: vlan_bond_device
+  register: vlan_bond_valid_mode_list
+- debug: var=vlan_bond_valid_mode_list
+- name: Collect VLAN devices with bad bond mode base interfaces
+  set_fact:
+    bbm_vlan: "{{ vlan_bond_item.ansible_facts.vlan_bond_valid_if }}"
+  when: not vlan_bond_item.ansible_facts.is_valid_bond_mode
+  with_items:
+    - "{{ vlan_bond_valid_mode_list.results }}"
+  loop_control:
+    loop_var: vlan_bond_item
+  register: bbm_vlan_list
+- debug: var=bbm_vlan_list
+- name: Generate invalid VLANs list
+  set_fact:
+    bad_vlan_bond_list: "{{ bbm_vlan_list.results | reject('skipped') | map(attribute='vlan_bond_item.ansible_facts.vlan_bond_valid_if') | list }}"
+- debug: var=bad_vlan_bond_list
+- name: Create list of unsupported network devices
+  set_fact:
+    invalid_net_if: "{{ bad_vlan_bond_list + team_if }}"
+- debug: var=invalid_net_if

--- a/roles/hosted_engine_setup/tasks/pre_checks/001_validate_network_interfaces.yml
+++ b/roles/hosted_engine_setup/tasks/pre_checks/001_validate_network_interfaces.yml
@@ -11,9 +11,11 @@
     loop_control:
       loop_var: bridge_name
   - debug: var=bridge_interface
-  - name: Get all active network interfaces
-    vars:
+  - name: Set variable for supported bond modes
+    set_fact:
       acceptable_bond_modes: ['active-backup', 'balance-xor', 'broadcast', '802.3ad']
+  - debug: var=acceptable_bond_modes
+  - name: Get all active network interfaces
     set_fact:
       otopi_net_host="{{ hostvars[inventory_hostname]['ansible_' + iface_item]['device'] }}"
       type="{{ hostvars[inventory_hostname]['ansible_' + iface_item]['type'] }}"
@@ -69,7 +71,7 @@
         {{ [bridge_interface] if bridge_interface is defined else bb_filtered_list.results |
         reject('skipped') | map(attribute='bond_item.ansible_facts.otopi_net_host') | list }}
   - debug: var=host_net
-  - import_tasks: filter_team_devices.yml
+  - import_tasks: filter_unsupported_devices.yml
   - name: Validate selected bridge interface if management bridge does not exist
     fail:
       msg: The selected network interface is not valid


### PR DESCRIPTION
Filter VLAN devices with bond parent configured with unsupported bond mode

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1585462
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>