### PR TITLE
examples: add recipe for removing DM device

### DIFF
--- a/examples/remove_mpath_device.yml
+++ b/examples/remove_mpath_device.yml
@@ -1,0 +1,17 @@
+---
+- name: Cleanly remove unzoned storage devices (LUNs)
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Get underlying disks (paths) for a multipath device and turn them into a list.
+      shell: dmsetup deps -o devname "{{ lun }}" | cut -f 2 |cut -c 3- |tr -d "()" | tr " " "\n"
+      register: disks
+
+    - name: Remove from multipath device.
+      shell: multipath -f "{{ lun }}"
+
+    - name: Remove each path from the SCSI subsystem.
+      shell: "echo 1 > /sys/block/{{ item }}/device/delete"
+      with_items:
+        - "{{ disks.stdout_lines }}"


### PR DESCRIPTION
To remove cleanly LUN from a hosts, one has to:

1. stop unsing it in oVirt (e.g. remove SD on top of this LUN)
2. unzone the LUN from storage server
3. remove multipath device for unzoned LUN from the hosts

As point 2. cannot be done oVirt, oVirt itself cannot automate whole
flow. This ansible recipe automates taks which needs to be done for
point 3. It cleanly removes multipath device which is not used any more.

Example usage:

    ansible-playbook  -i hosts --extra-vars "lun=36001405042dd41f40334273abc579952" remove_mpath_device.yml

Extra parameter `lun` which is passed to the recipe is WWID of the LUN
as reported e.g. by `multipath -l`.

Bug-Url: https://bugzilla.redhat.com/1310330