### PR TITLE
ansible-builder: add execution-environment.yml

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,0 +1,12 @@
+---
+version: 1
+dependencies:
+  system: bindep.txt
+
+additional_build_steps:
+  prepend: |
+    RUN pip3 install --upgrade pip setuptools
+    RUN dnf install https://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm -y
+    RUN dnf install ovirt-ansible-collection -y
+  append:
+    - RUN ls -la /usr/share/ansible/collections/ansible_collections/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ovirt-engine-sdk-python>=4.4.10


### PR DESCRIPTION
**General info**
Creating of container image
`ansible-builder build --tag ovirt --container-runtime docker -v 3`

Using the image to run the playbook with dependencies with ansible-runner.
(We need to have an ansible-runner devel version which supports --container-image)
`ansible-runner playbook --container-image=ovirt playbook_name.yml -vvv `


**Issue in the PR**
Currently, the playbook fails because it does not see the collection.

I tried to debug it by adding to the end of `execution-enviroment.yml`, I added
`RUN ls -la /usr/share/ansible/collections/ansible_collections/` we can see the installed `ovirt.ovirt` collection correctly.

But when I try to list it with the playbook below and execute it as above, the playbook does not see the directory.
```
- hosts: localhost
  tasks:
    - name: List path
      find:
        paths: /usr/share/ansible/collections/ansible_collections/
```
