### PR TITLE
Remove ansible channels from RHV 4.4

### DIFF
--- a/roles/repositories/vars/engine_4.4.yml
+++ b/roles/repositories/vars/engine_4.4.yml
@@ -2,6 +2,5 @@ ovirt_repositories_subscription_manager_repos:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
   - rhv-4.4-manager-for-rhel-8-x86_64-rpms
-  - ansible-2.9-for-rhel-8-x86_64-rpms
   - jb-eap-7.3-for-rhel-8-x86_64-rpms
   - fast-datapath-for-rhel-8-x86_64-rpms

--- a/roles/repositories/vars/host_4.4.yml
+++ b/roles/repositories/vars/host_4.4.yml
@@ -2,6 +2,5 @@ ovirt_repositories_subscription_manager_repos:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
   - rhv-4-mgmt-agent-for-rhel-8-x86_64-rpms
-  - ansible-2.9-for-rhel-8-x86_64-rpms
   - advanced-virt-for-rhel-8-x86_64-rpms
   - fast-datapath-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
As mentioned in https://bugzilla.redhat.com/1917409 from RHV 4.4.5
required ansible version is provided by RHV channels, so specific
ansible channel is no longer needed on RHV manager no RHV hosts.

Signed-off-by: Martin Perina <mperina@redhat.com>