### PR TITLE
infra: fix storage target

### DIFF
--- a/roles/infra/roles/storages/tasks/main.yml
+++ b/roles/infra/roles/storages/tasks/main.yml
@@ -91,7 +91,7 @@
     username: "{{ storages[item.0.name][item.0.storage.type].username | default(omit) }}"
     password: "{{ storages[item.0.name][item.0.storage.type].password | default(omit) }}"
     port: "{{ storages[item.0.name][item.0.storage.type].port | default(omit) }}"
-    target: "{{ storages[item.0.name][item.0.storage.type].target | default(omit) }}"
+    target: "{% if storages[item.0.name][item.0.storage.type].target not in item.0.storage.volume_group.logical_units | map(attribute='target') | list %}{{ storages[item.0.name][item.0.storage.type].target | default(omit) }}{% else %}{{ omit }}{% endif %}"
     force: true
   with_subelements:
     - "{{ sd_info.ovirt_storage_domains | default([]) }}"


### PR DESCRIPTION
The issue was that the role was trying to edit the storage connection
target when the storage domain has multiple connection targets.

This patch checks if the target which user input is in the list
of targets from the storage domain if so it will ignore it else it will edit
it.

https://bugzilla.redhat.com/show_bug.cgi?id=1943221