### PR TITLE
role: hosted_engine_setup: Get the appliance distribution in a correct way

### DIFF
--- a/roles/hosted_engine_setup/tasks/apply_openscap_profile.yml
+++ b/roles/hosted_engine_setup/tasks/apply_openscap_profile.yml
@@ -1,12 +1,16 @@
 ---
+- name: Get appliance distribution
+  setup:
+    filter: ansible_distribution*
+  register: appliance_dist
 - name: Initialize OpenSCAP variables
   set_fact:
     oscap_dir: "/usr/share/xml/scap/ssg/content"
-    oscap_dist: "{{ ansible_distribution | replace('RedHat', 'rhel') | lower }}"
-    oscap_ver: "{{ ansible_distribution_major_version if ansible_distribution != 'Fedora' else '' }}"
+    oscap_dist: "{{ appliance_dist.ansible_facts.ansible_distribution }}"
+    oscap_ver: "{{ appliance_dist.ansible_facts.ansible_distribution_major_version if ansible_distribution != 'Fedora' else '' }}"
 - name: Set OpenSCAP datastream path
   set_fact:
-    oscap_datastream: "{{ oscap_dir }}/ssg-{{ oscap_dist }}{{ oscap_ver }}-ds.xml"
+    oscap_datastream: "{{ oscap_dir }}/ssg-{{ oscap_dist | replace('RedHat', 'rhel') | lower }}{{ oscap_ver }}-ds.xml"
 - debug: var=oscap_datastream
 - name: Verify OpenSCAP datastream
   stat:
@@ -27,6 +31,7 @@
   failed_when: false
   ignore_errors: true
   changed_when: true
+  when: oscap_profile.stdout is defined
 - name: Reset PermitRootLogin for sshd
   lineinfile: dest=/etc/ssh/sshd_config
               regexp="^\s*PermitRootLogin"
@@ -45,4 +50,4 @@
       fail:
         msg: "FIPS mode is not enabled as required"
       when: he_fips_enabled.stdout != "1"
-  when: ansible_distribution is search("RedHat")
+  when: oscap_dist == "RedHat"


### PR DESCRIPTION
Use Setup module in order to fetch ansible distribution from the appliance

Bug-Url: https://bugzilla.redhat.com/1948274
Signed-off-by: Asaf Rachmani <arachman@redhat.com>