### PR TITLE
role: hosted_engine_setup: Add an error message for FIPS on CentOS

### DIFF
--- a/roles/hosted_engine_setup/tasks/apply_openscap_profile.yml
+++ b/roles/hosted_engine_setup/tasks/apply_openscap_profile.yml
@@ -40,14 +40,16 @@
 - name: Reboot the engine VM to ensure that FIPS is enabled
   reboot:
     reboot_timeout: 1200
-- block:
-    - name: Check if FIPS is enabled
-      command: sysctl -n crypto.fips_enabled
-      changed_when: true
-      register: he_fips_enabled
-    - debug: var=he_fips_enabled
-    - name: Enforce FIPS mode
-      fail:
-        msg: "FIPS mode is not enabled as required"
-      when: he_fips_enabled.stdout != "1"
-  when: oscap_dist == "RedHat"
+- name: Check if FIPS mode is enabled
+  command: sysctl -n crypto.fips_enabled
+  changed_when: true
+  register: he_fips_enabled
+- debug: var=he_fips_enabled
+- name: Enforce FIPS mode on CentOS
+  fail:
+    msg: "FIPS mode is unsupported on CentOS"
+  when:  oscap_dist == "CentOS" and he_fips_enabled.stdout != "1"
+- name: Enforce FIPS mode on Rhel
+  fail:
+    msg: "FIPS mode is not enabled as required"
+  when:  oscap_dist == "RedHat" and he_fips_enabled.stdout != "1"


### PR DESCRIPTION
Add an error message when using FIPS mode on an appliance based on CentOS
in case the FIPS mode cannot be applied.

Bug-Url: https://bugzilla.redhat.com/1924590
Signed-off-by: Asaf Rachmani <arachman@redhat.com>