### PR TITLE
info modules: add follow parameter

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -70,7 +70,7 @@ cd $COLLECTION_DIR
 
 pip3 install rstcheck antsibull-changelog "ansible-lint<5.0.0"
 
-ansible-test sanity
+/usr/local/bin/ansible-test sanity
 /usr/local/bin/antsibull-changelog lint
 /usr/local/bin/ansible-lint roles/* -x 204
 

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -70,7 +70,7 @@ cd $COLLECTION_DIR
 
 pip3 install rstcheck antsibull-changelog "ansible-lint<5.0.0"
 
-/usr/bin/ansible-test sanity
+ansible-test sanity
 /usr/local/bin/antsibull-changelog lint
 /usr/local/bin/ansible-lint roles/* -x 204
 

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -70,7 +70,7 @@ cd $COLLECTION_DIR
 
 pip3 install rstcheck antsibull-changelog "ansible-lint<5.0.0"
 
-/usr/local/bin/ansible-test sanity
+/usr/bin/ansible-test sanity
 /usr/local/bin/antsibull-changelog lint
 /usr/local/bin/ansible-lint roles/* -x 204
 

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -25,14 +25,6 @@ options:
             - This parameter apply only when C(fetch_nested) is I(true).
         type: list
         elements: str
-    follows:
-      description:
-        - List of follow link names which will be gathered.
-        - This parameter replaces use of C(fetch_nested) and C(nested_attributes).
-        - If C(follows) is specified it uses over C(fetch_nested).
-      type: list
-      version_added: 1.4.0
-      elements: str
     auth:
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -18,13 +18,22 @@ options:
             - It will fetch only IDs of nested entity. It doesn't fetch multiple levels of nested attributes.
               Only the attributes of the current entity. User can configure to fetch other
               attributes of the nested entities by specifying C(nested_attributes).
+            - This parameter is deprecated and replaced by C(follows).
         type: bool
     nested_attributes:
         description:
             - Specifies list of the attributes which should be fetched from the API.
             - This parameter apply only when C(fetch_nested) is I(true).
+            - This parameter is deprecated and replaced by C(follows).
         type: list
         elements: str
+    follows:
+      description:
+        - List of follow link names which will be gathered.
+        - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+      type: list
+      version_added: 1.5.0
+      elements: str
     auth:
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -25,6 +25,14 @@ options:
             - This parameter apply only when C(fetch_nested) is I(true).
         type: list
         elements: str
+    follows:
+      description:
+        - List of follow link names which will be gathered.
+        - This parameter replaces use of C(fetch_nested) and C(nested_attributes).
+        - If C(follows) is specified it uses over C(fetch_nested).
+      type: list
+      version_added: 1.4.0
+      elements: str
     auth:
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -29,7 +29,7 @@ options:
         elements: str
     follows:
       description:
-        - List of follow link names which will be gathered.
+        - List of linked entities, which should be fetched along with the main entity.
         - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
       type: list
       version_added: 1.5.0

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -454,6 +454,7 @@ def ovirt_info_full_argument_spec(**kwargs):
         auth=__get_auth_dict(),
         fetch_nested=dict(default=False, type='bool'),
         nested_attributes=dict(type='list', default=list(), elements='str'),
+        follows=dict(default=list(), type='list'),
     )
     spec.update(kwargs)
     return spec

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -66,26 +66,31 @@ def remove_underscore(val):
     return val
 
 
-def get_dict_of_struct_follow(struct):
+def get_dict_of_struct_follow(struct, filter_keys):
     if isinstance(struct, sdk.Struct):
         res = {}
         for key, value in struct.__dict__.items():
             if value is None:
                 continue
             key = remove_underscore(key)
-            res[key] = get_dict_of_struct_follow(value)
+
+            if filter_keys is None or key in filter_keys:
+                res[key] = get_dict_of_struct_follow(value, filter_keys)
         return res
     elif isinstance(struct, Enum) or isinstance(struct, datetime):
         return str(struct)
     elif isinstance(struct, list) or isinstance(struct, sdk.List):
-        return [get_dict_of_struct_follow(i) for i in struct]
+        return [get_dict_of_struct_follow(i, filter_keys) for i in struct]
     return struct
 
 
-def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None):
+def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None, follow=None):
     """
     Convert SDK Struct type into dictionary.
     """
+    if follow:
+        return get_dict_of_struct_follow(struct, filter_keys)
+
     res = {}
 
     def resolve_href(value):

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -73,7 +73,6 @@ def get_dict_of_struct_follow(struct, filter_keys):
             if value is None:
                 continue
             key = remove_underscore(key)
-
             if filter_keys is None or key in filter_keys:
                 res[key] = get_dict_of_struct_follow(value, filter_keys)
         return res
@@ -84,11 +83,11 @@ def get_dict_of_struct_follow(struct, filter_keys):
     return struct
 
 
-def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None, follow=None):
+def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None, follows=None):
     """
     Convert SDK Struct type into dictionary.
     """
-    if follow:
+    if follows:
         return get_dict_of_struct_follow(struct, filter_keys)
 
     res = {}

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -59,6 +59,29 @@ def check_sdk(module):
         )
 
 
+def remove_underscore(val):
+    if val.startswith('_'):
+        val = val[1:]
+        remove_underscore(val)
+    return val
+
+
+def get_dict_of_struct_follow(struct):
+    if isinstance(struct, sdk.Struct):
+        res = {}
+        for key, value in struct.__dict__.items():
+            if value is None:
+                continue
+            key = remove_underscore(key)
+            res[key] = get_dict_of_struct_follow(value)
+        return res
+    elif isinstance(struct, Enum) or isinstance(struct, datetime):
+        return str(struct)
+    elif isinstance(struct, list) or isinstance(struct, sdk.List):
+        return [get_dict_of_struct_follow(i) for i in struct]
+    return struct
+
+
 def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=None, filter_keys=None):
     """
     Convert SDK Struct type into dictionary.
@@ -78,12 +101,6 @@ def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=N
         nested_obj['id'] = getattr(value, 'id', None)
         nested_obj['href'] = getattr(value, 'href', None)
         return nested_obj
-
-    def remove_underscore(val):
-        if val.startswith('_'):
-            val = val[1:]
-            remove_underscore(val)
-        return val
 
     def convert_value(value):
         nested = False

--- a/plugins/modules/ovirt_affinity_label_info.py
+++ b/plugins/modules/ovirt_affinity_label_info.py
@@ -118,6 +118,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_api_info.py
+++ b/plugins/modules/ovirt_api_info.py
@@ -60,6 +60,8 @@ def main():
     argument_spec = ovirt_info_full_argument_spec()
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_cluster_info.py
+++ b/plugins/modules/ovirt_cluster_info.py
@@ -86,6 +86,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_datacenter_info.py
+++ b/plugins/modules/ovirt_datacenter_info.py
@@ -70,6 +70,8 @@ def main():
     module = AnsibleModule(argument_spec)
 
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_disk_info.py
+++ b/plugins/modules/ovirt_disk_info.py
@@ -83,6 +83,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_event_info.py
+++ b/plugins/modules/ovirt_event_info.py
@@ -116,6 +116,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_external_provider_info.py
+++ b/plugins/modules/ovirt_external_provider_info.py
@@ -116,6 +116,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_group_info.py
+++ b/plugins/modules/ovirt_group_info.py
@@ -82,6 +82,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_host_info.py
+++ b/plugins/modules/ovirt_host_info.py
@@ -102,6 +102,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -134,6 +134,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_network_info.py
+++ b/plugins/modules/ovirt_network_info.py
@@ -86,6 +86,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_nic_info.py
+++ b/plugins/modules/ovirt_nic_info.py
@@ -102,6 +102,8 @@ def main():
         required_one_of=[['vm', 'template']],
     )
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_permission_info.py
+++ b/plugins/modules/ovirt_permission_info.py
@@ -131,6 +131,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_quota_info.py
+++ b/plugins/modules/ovirt_quota_info.py
@@ -90,6 +90,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -89,6 +89,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_snapshot_info.py
+++ b/plugins/modules/ovirt_snapshot_info.py
@@ -83,6 +83,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_storage_domain_info.py
+++ b/plugins/modules/ovirt_storage_domain_info.py
@@ -86,6 +86,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_storage_template_info.py
+++ b/plugins/modules/ovirt_storage_template_info.py
@@ -95,6 +95,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_storage_vm_info.py
+++ b/plugins/modules/ovirt_storage_vm_info.py
@@ -95,6 +95,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -84,6 +84,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_tag_info.py
+++ b/plugins/modules/ovirt_tag_info.py
@@ -109,6 +109,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_template_info.py
+++ b/plugins/modules/ovirt_template_info.py
@@ -86,6 +86,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_user_info.py
+++ b/plugins/modules/ovirt_user_info.py
@@ -82,6 +82,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -70,14 +70,6 @@ options:
         - "If I(true) it will get from all virtual machines current attached cd."
       type: bool
       version_added: 1.2.0
-    follows:
-      description:
-        - List of follow link names which will be gathered.
-        - This parameter replaces use of C(fetch_nested) and C(nested_attributes).
-        - If C(follows) is specified it uses over C(fetch_nested).
-      type: list
-      version_added: 1.4.0
-      elements: str
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 
@@ -132,7 +124,6 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
 def main():
     argument_spec = ovirt_info_full_argument_spec(
         pattern=dict(default='', required=False),
-        follows=dict(default=[], type='list'),
         all_content=dict(default=False, type='bool'),
         current_cd=dict(default=False, type='bool'),
         next_run=dict(default=None, type='bool'),
@@ -141,6 +132,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.13')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -70,6 +70,14 @@ options:
         - "If I(true) it will get from all virtual machines current attached cd."
       type: bool
       version_added: 1.2.0
+    follows:
+      description:
+        - List of follow link names which will be gathered.
+        - This parameter replaces use of C(fetch_nested) and C(nested_attributes).
+        - If C(follows) is specified it uses over C(fetch_nested).
+      type: list
+      version_added: 1.4.0
+      elements: str
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 
@@ -155,7 +163,7 @@ def main():
                     connection=connection,
                     fetch_nested=module.params.get('fetch_nested'),
                     attributes=module.params.get('nested_attributes'),
-                    follow=module.params['follows'],
+                    follows=module.params.get('follows'),
                 ) for c in vms
             ],
         )

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
 # Gather info about VMs original template with follow parameter
 - @NAMESPACE@.@NAME@.ovirt_vm_info:
     pattern: name=myvm
-    follows: ['original_template.permissions','original_template.diskattachments']
+    follows: ['original_template.permissions', 'original_template.nics.vnic_profile']
   register: result
 - ansible.builtin.debug:
     msg: "{{ result.ovirt_vms[0] }}"
@@ -116,7 +116,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
-    get_dict_of_struct_follow,
+    get_dict_of_struct,
     ovirt_info_full_argument_spec,
 )
 
@@ -124,7 +124,7 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
 def main():
     argument_spec = ovirt_info_full_argument_spec(
         pattern=dict(default='', required=False),
-        follows=dict(default=None, type='list'),
+        follows=dict(default=[], type='list'),
         all_content=dict(default=False, type='bool'),
         current_cd=dict(default=False, type='bool'),
         next_run=dict(default=None, type='bool'),
@@ -150,8 +150,12 @@ def main():
 
         result = dict(
             ovirt_vms=[
-                get_dict_of_struct_follow(
+                get_dict_of_struct(
                     struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                    follow=module.params['follows'],
                 ) for c in vms
             ],
         )

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -133,7 +133,7 @@ def main():
     module = AnsibleModule(argument_spec)
     check_sdk(module)
     if module.params['fetch_nested'] or module.params['nested_attributes']:
-        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.13')
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -93,6 +93,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_vmpool_info.py
+++ b/plugins/modules/ovirt_vmpool_info.py
@@ -84,6 +84,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')

--- a/plugins/modules/ovirt_vnic_profile_info.py
+++ b/plugins/modules/ovirt_vnic_profile_info.py
@@ -84,6 +84,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
+    if module.params['fetch_nested'] or module.params['nested_attributes']:
+        module.deprecate("The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter", version='2.0')
 
     try:
         auth = module.params.pop('auth')


### PR DESCRIPTION
We have multiple issues with the info modules.
1. the `get_dict_of_struct` function uses `connection.follow_link` which creates a request for each nested parameter and this slows the gathering of data. Using the `follow` in `list` speeds this process us because we leave it up to the engine and get all required data in one request.
2. We filter all nested data even if it was passed in the request. Now it shows exactly the same resp as in the API. (Could resolve issue https://github.com/oVirt/ovirt-ansible-collection/issues/246)