### PR TITLE
roles: hosted_engine_setup: Add pause option before running engine-setup

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-add-pause-option-before-engine-setup.yml
+++ b/changelogs/fragments/hosted_engine_setup-add-pause-option-before-engine-setup.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - Add-pause-option-before-engine-setup (https://github.com/oVirt/ovirt-ansible-collection/pull/273).

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -44,6 +44,7 @@ Ansible role for deploying oVirt Hosted-Engine
 | he_tcp_t_port | null | port to connect if he_network_test is *tcp* |
 | he_pause_host | false | Pause the execution to let the user interactively fix host configuration |
 | he_pause_after_failed_add_host | true | Pause the execution if Add Host failed with status non_operational, to let the user interactively fix host configuration |
+| he_pause_before_engine_setup | false | Pause the execution and allow the user to make configuration changes to the bootstrap engine VM before running `engine-setup` |
 | he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 | he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
 | he_debug_mode | false | If `True`, HE deployment will execute additional tasks for debug |
@@ -358,7 +359,11 @@ These playbooks will be consumed automatically by the role when you execute it.
 
 **Manual:**
 
-To make manual adjustments you can set the variable ```he_pause_host``` to true. This will pause the deployment after the engine has been setup and create a lock-file at /tmp that ends with ```_he_setup_lock``` on the machine the role was executed on. The deployment will continue after deleting the lock-file, or after 24 hours ( if the lock-file hasn't been removed ).
+To make manual adjustments set the following variables to `true`:
+- `he_pause_before_engine_setup` - This will pause the deployment **before** running the engine setup.
+- `he_pause_host` - This will pause the deployment **after** the engine has been setup.
+
+Set these variables to `true` will create a lock-file at /tmp that ends with `_he_setup_lock` on the machine the role was executed on. The deployment will continue after deleting the lock-file, or after 24 hours ( if the lock-file hasn't been removed ).
 
 In order to proceed with the deployment, before deleting the lock-file, make sure that the host is on 'up' state at the engine's URL.
 

--- a/roles/hosted_engine_setup/defaults/main.yml
+++ b/roles/hosted_engine_setup/defaults/main.yml
@@ -48,6 +48,7 @@ he_source_email: root@localhost
 he_force_ip4: false
 he_force_ip6: false
 
+he_pause_before_engine_setup: false
 he_pause_host: false
 he_pause_after_failed_add_host: true
 he_debug_mode: false

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -65,8 +65,8 @@
       - name: Allow the user to connect to the bootstrap engine and change configuration
         debug:
           msg: >-
-            You can now connect to the bootstrap engine using the temporary IP address -
-            {{ hostvars[he_ansible_host_name]['local_vm_ip']['stdout_lines'][0] }}
+            You can now connect from this host to the bootstrap engine VM using ssh as root
+            and the temporary IP address - {{ hostvars[he_ansible_host_name]['local_vm_ip']['stdout_lines'][0] }}
       - include_tasks: ../pause_execution.yml
     when: he_pause_before_engine_setup|bool
   - name: Restore a backup

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -60,6 +60,15 @@
     include_tasks: "{{ item }}"
     with_fileglob: "hooks/enginevm_before_engine_setup/*.yml"
     register: include_before_engine_setup_results
+  - name: Pause the execution to allow the user to configure the bootstrap engine VM
+    block:
+      - name: Allow the user to connect to the bootstrap engine and change configuration
+        debug:
+          msg: >-
+            You can now connect to the bootstrap engine using the temporary IP address -
+            {{ hostvars[he_ansible_host_name]['local_vm_ip']['stdout_lines'][0] }}
+      - include_tasks: ../pause_execution.yml
+    when: he_pause_before_engine_setup|bool
   - name: Restore a backup
     block:
       - include_tasks: ../restore_backup.yml


### PR DESCRIPTION
Add the option to pause the deployment and adjust changes in the
bootstrap engine VM before running the engine-setup

Bug-Url: https://bugzilla.redhat.com/1959273
Signed-off-by: Asaf Rachmani <arachman@redhat.com>