### PR TITLE
 role: hosted_engine_setup: add_host: Use local_vm_ip

### DIFF
--- a/changelogs/fragments/hosted_engine_setup-add-host-use_IP.yml
+++ b/changelogs/fragments/hosted_engine_setup-add-host-use_IP.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - use-ansible-host (https://github.com/oVirt/ovirt-ansible-collection/pull/277).

--- a/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
+++ b/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
@@ -18,6 +18,7 @@
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
         {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
+      ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
       ansible_user: root
     no_log: true
     ignore_errors: true

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -1,7 +1,6 @@
 ---
 - name: Create hosted engine local vm
   block:
-  - import_tasks: ../add_engine_as_ansible_host.yml
   - name: Initial tasks
     block:
       - name: Get host unique id
@@ -133,6 +132,7 @@
           port=22
           delay=30
           timeout=300
+      - import_tasks: ../add_engine_as_ansible_host.yml
     rescue:
       - include_tasks: ../clean_localvm_dir.yml
       - include_tasks: ../clean_local_storage_pools.yml

--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create target Hosted Engine VM
   block:
-  - import_tasks: ../add_engine_as_ansible_host.yml
   - include_tasks: ../auth_sso.yml
   - name: Get local VM IP
     shell: virsh -r net-dhcp-leases default | grep -i {{ he_vm_mac_addr }} | awk '{ print $5 }' | cut -f1 -d'/'
     environment: "{{ he_cmd_lang }}"
     register: local_vm_ip
     changed_when: true
+  - import_tasks: ../add_engine_as_ansible_host.yml
   - name: Fetch host facts
     ovirt_host_info:
       pattern: name={{ he_host_name }} status=up


### PR DESCRIPTION
Do not rely on adding a line to /etc/hosts, as this seems to not be
enough sometimes. Instead, directly tell ansible to use the IP address.

Bug-Url: https://bugzilla.redhat.com/1953029