### PR TITLE
Removing 6900/tcp port from firewall to enable HE deployment

### DIFF
--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -1,4 +1,9 @@
 ---
+- name: Remove port 6900/tcp to enable HE deployment
+  ansible.posix.firewalld:
+    port: 6900/tcp
+    permanent: yes
+    state: disabled
 - name: Add host
   block:
   - name: Wait for ovirt-engine service to start


### PR DESCRIPTION
Bug-Id: https://github.com/oVirt/ovirt-ansible-collection/issues/283
Signed-off-by: parthdhanjal <dparth@redhat.com>