### PR TITLE
DR: change conf paths

### DIFF
--- a/changelogs/fragments/286-dr-change-conf-paths.yml
+++ b/changelogs/fragments/286-dr-change-conf-paths.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - disaster_recovery - Change conf paths (https://github.com/oVirt/ovirt-ansible-collection/pull/286).

--- a/roles/disaster_recovery/files/dr.conf
+++ b/roles/disaster_recovery/files/dr.conf
@@ -7,15 +7,15 @@ site=http://engine.example.com/ovirt-engine/api
 username=admin@internal
 password=
 ca_file=/etc/pki/ovirt-engine/ca.pem
-output_file=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/disaster_recovery_vars.yml
-ansible_play=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/dr_play.yml
+output_file=../examples/disaster_recovery_vars.yml
+ansible_play=../examples/dr_play.yml
 
 [validate_vars]
-var_file=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/disaster_recovery_vars.yml
+var_file=../examples/disaster_recovery_vars.yml
 
 [failover_failback]
 dr_target_host=secondary
 dr_source_map=primary
-vault=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/ovirt_passwords.yml
-var_file=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/disaster_recovery_vars.yml
-ansible_play=~/.ansible/collections/ansible_collections/@NAMESPACE@/@NAME@/roles/disaster_recovery/examples/dr_play.yml
+vault=../examples/ovirt_passwords.yml
+var_file=../examples/disaster_recovery_vars.yml
+ansible_play=../examples/dr_play.yml


### PR DESCRIPTION
Issue: When installing only from RPM the paths which were in the `dr.conf` were missing so after the DR started it created the paths and it blocked the usage of the collection because the `~/.ansible` path has higher priority than the `/usr/share/ansible`
https://bugzilla.redhat.com/show_bug.cgi?id=1965228