### PR TITLE
Allow downstream name for inventory plugin

### DIFF
--- a/changelogs/fragments/inventory_plugin_key_choices.yml
+++ b/changelogs/fragments/inventory_plugin_key_choices.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt inventory plugin - allow several valid values for the `plugin` key (https://github.com/oVirt/ovirt-ansible-collection/pull/293).

--- a/plugins/inventory/ovirt.py
+++ b/plugins/inventory/ovirt.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
       plugin:
         description: the name of this plugin, it should always be set to 'ovirt' for this plugin to recognise it as it's own.
         required: True
-        choices: ['ovirt']
+        choices: ['ovirt', 'ovirt.ovirt.ovirt', 'redhat.rhv.ovirt']
       ovirt_url:
         description: URL to ovirt-engine API.
         required: True


### PR DESCRIPTION
Testing with the collection from Automation Hub

```
[WARNING]:  * Failed to parse /runner/inventory/ovirt.yml with auto plugin:
Invalid value "redhat.rhv.ovirt" for configuration option "plugin_type:
inventory plugin: ansible_collections.redhat.rhv.plugins.inventory.ovirt
setting: plugin ", valid values are: ['ovirt']
  File "/usr/lib/python3.8/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python3.8/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/usr/share/ansible/collections/ansible_collections/redhat/rhv/plugins/inventory/ovirt.py", line 238, in parse
    config = self._read_config_data(path)
  File "/usr/lib/python3.8/site-packages/ansible/plugins/inventory/__init__.py", line 239, in _read_config_data
    self.set_options(direct=config, var_options=self._vars)
```

