### PR TITLE
roles: hosted_engine_setup: Use FQDN instead of IP for ansible host

### DIFF
--- a/changelogs/fragments/302-hosted_engine_setup-use-fqdn-for-ansible-host.yml
+++ b/changelogs/fragments/302-hosted_engine_setup-use-fqdn-for-ansible-host.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - use fqdn for ansible host (https://github.com/oVirt/ovirt-ansible-collection/pull/302).

--- a/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
+++ b/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
@@ -18,7 +18,6 @@
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
         {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
-      ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
       ansible_user: root
     no_log: true
     ignore_errors: true


### PR DESCRIPTION
`delegate_to: "{{ groups.engine[0] }}"` currently tries to reach the engine VM using IP address.
Reaching the bootstrap VM will succeed but, the operation will fail once the local VM is present,
since it uses a different IP address.
Using FQDN instead of an IP address should fix the issue.

Bug-Url: https://bugzilla.redhat.com/1973640
Signed-off-by: Asaf Rachmani <arachman@redhat.com>