### PR TITLE
Don't rely on safe_eval being able to do math/concat

### DIFF
--- a/changelogs/fragments/307-safe-eval-no-concat.yml
+++ b/changelogs/fragments/307-safe-eval-no-concat.yml
@@ -1,3 +1,4 @@
+---
 trivial:
-- Don't rely on ``safe_eval`` being able to do math/concat
-  (https://github.com/oVirt/ovirt-ansible-collection/pull/307)
+  - Don't rely on ``safe_eval`` being able to do math/concat
+    (https://github.com/oVirt/ovirt-ansible-collection/pull/307)

--- a/changelogs/fragments/307-safe-eval-no-concat.yml
+++ b/changelogs/fragments/307-safe-eval-no-concat.yml
@@ -1,0 +1,3 @@
+trivial:
+- Don't rely on ``safe_eval`` being able to do math/concat
+  (https://github.com/oVirt/ovirt-ansible-collection/pull/307)

--- a/roles/disaster_recovery/tasks/recover/register_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vms.yml
@@ -9,7 +9,7 @@
 
     - name: Set unregistered VMs
       set_fact:
-          unreg_vms: "{{ unreg_vms|default([]) }} + {{ storage_vm_info.ovirt_storage_vms }}"
+          unreg_vms: "{{ unreg_vms|default([]) + storage_vm_info.ovirt_storage_vms }}"
 
     # TODO: We should filter out VMs which already exist in the setup (diskless VMs)
     - name: Register VM

--- a/roles/disaster_recovery/tasks/recover_engine.yml
+++ b/roles/disaster_recovery/tasks/recover_engine.yml
@@ -76,7 +76,7 @@
 
     - name: Set Cluster Map
       set_fact:
-          dr_cluster_map: "{{ dr_cluster_map }} + {{ [
+          dr_cluster_map: "{{ dr_cluster_map + [
           {
               'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
               'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
@@ -87,7 +87,7 @@
 
     - name: Set Affinity Group Map
       set_fact:
-          dr_affinity_group_map: "{{ dr_affinity_group_map }} + {{ [
+          dr_affinity_group_map: "{{ dr_affinity_group_map + [
           {
               'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
               'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
@@ -98,7 +98,7 @@
 
     - name: Set Network Map
       set_fact:
-          dr_network_map: "{{ dr_network_map }} + {{ [
+          dr_network_map: "{{ dr_network_map + [
           {
               'source_network_name': item[dr_source_map + '_network_name'] | default('EMPTY_ELEMENT', true),
               'source_profile_name': item[dr_source_map + '_profile_name'] | default('EMPTY_ELEMENT', true),
@@ -111,7 +111,7 @@
 
     - name: Set Affinity Label Map
       set_fact:
-          dr_affinity_label_map: "{{ dr_affinity_label_map }} + {{ [
+          dr_affinity_label_map: "{{ dr_affinity_label_map + [
           {
               'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
               'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
@@ -122,7 +122,7 @@
 
     - name: Set aaa extensions Map
       set_fact:
-          dr_domain_map: "{{ dr_domain_map }} + {{ [
+          dr_domain_map: "{{ dr_domain_map + [
           {
               'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
               'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
@@ -133,7 +133,7 @@
 
     - name: Set Role Map
       set_fact:
-          dr_role_map: "{{ dr_role_map }} + {{ [
+          dr_role_map: "{{ dr_role_map + [
           {
               'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
               'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
@@ -144,7 +144,7 @@
 
     - name: Set Lun Map
       set_fact:
-          dr_lun_map: "{{ dr_lun_map }} + {{ [
+          dr_lun_map: "{{ dr_lun_map + [
           {
               'source_logical_unit_id': item[dr_source_map + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
               'source_storage_type': item[dr_source_map + '_storage_type'] | default('EMPTY_ELEMENT', true),

--- a/roles/disaster_recovery/tasks/unregister_entities.yml
+++ b/roles/disaster_recovery/tasks/unregister_entities.yml
@@ -29,7 +29,7 @@
 
     - name: Map all running vms in fact
       set_fact:
-          res_ovirt_vms: "{{ res_ovirt_vms }} + {{ [
+          res_ovirt_vms: "{{ res_ovirt_vms + [
               {
                   'id': item.id,
                   'name': item.name,


### PR DESCRIPTION
Don't rely on `safe_eval` being able to do math/concat. This functionality will be removed in ansible-core 2.12, and has never worked with jinja2 native which we are working toward making the default in 2.12.

See https://github.com/ansible/ansible/pull/75068