### PR TITLE
role: hosted_engine_setup: Fix engine vm add_host for the target machine

### DIFF
--- a/changelogs/fragments/311-fix-add-host-target-vm.yml
+++ b/changelogs/fragments/311-fix-add-host-target-vm.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-        - hosted_engine_setup: Fix engine vm add_host for the target machine (https://github.com/oVirt/ovirt-ansible-collection/pull/311)
+  - hosted_engine_setup - Fix engine vm add_host for the target machine (https://github.com/oVirt/ovirt-ansible-collection/pull/311)

--- a/changelogs/fragments/311-fix-add-host-target-vm.yml
+++ b/changelogs/fragments/311-fix-add-host-target-vm.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+        - hosted_engine_setup: Fix engine vm add_host for the target machine (https://github.com/oVirt/ovirt-ansible-collection/pull/311)

--- a/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
+++ b/roles/hosted_engine_setup/tasks/add_engine_as_ansible_host.yml
@@ -18,7 +18,7 @@
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
         {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
-      ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
+      ansible_host: "{{ he_fqdn_ansible_host }}"
       ansible_user: root
     no_log: true
     ignore_errors: true

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -132,6 +132,9 @@
           port=22
           delay=30
           timeout=300
+      - name: Set the name for add_host
+        set_fact:
+          he_fqdn_ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
       - import_tasks: ../add_engine_as_ansible_host.yml
     rescue:
       - include_tasks: ../clean_localvm_dir.yml

--- a/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -7,6 +7,9 @@
     environment: "{{ he_cmd_lang }}"
     register: local_vm_ip
     changed_when: true
+  - name: Set the name for add_host
+    set_fact:
+      he_fqdn_ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
   - import_tasks: ../add_engine_as_ansible_host.yml
   - name: Fetch host facts
     ovirt_host_info:

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -260,6 +260,10 @@
       dest: /etc/hosts
       regexp: "# temporary entry added by hosted-engine-setup for the bootstrap VM$"
       state: absent
+  - name: Set the name for add_host
+    set_fact:
+      he_fqdn_ansible_host: "{{ he_fqdn }}"
+  - import_tasks: ../add_engine_as_ansible_host.yml
   - name: Start ovirt-ha-broker service on the host
     service:
       name: ovirt-ha-broker

--- a/roles/hosted_engine_setup/tasks/sync_on_engine_machine.yml
+++ b/roles/hosted_engine_setup/tasks/sync_on_engine_machine.yml
@@ -1,4 +1,7 @@
 ---
+- name: Set the name for add_host
+  set_fact:
+    he_fqdn_ansible_host: "{{ local_vm_ip.stdout_lines[0] }}"
 - name: Register the engine VM as an ansible host
   import_tasks: add_engine_as_ansible_host.yml
 - name: Sync on engine machine


### PR DESCRIPTION
Allow custom hooks that want to access the engine VM as an ansible host
to work also after it is started as the target public machine.