### PR TITLE
roles: hosted_engine_setup: remove duplicate tasks

### DIFF
--- a/changelogs/fragments/314-remove-duplicate-tasks.yml
+++ b/changelogs/fragments/314-remove-duplicate-tasks.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - remove duplicate tasks (https://github.com/oVirt/ovirt-ansible-collection/pull/314)

--- a/roles/hosted_engine_setup/tasks/partial_execution.yml
+++ b/roles/hosted_engine_setup/tasks/partial_execution.yml
@@ -120,11 +120,11 @@
   import_tasks: sync_on_engine_machine.yml
   changed_when: true
   ignore_errors: true
-  tags: [create_target_vm, final_clean, never]
+  tags: [final_clean, never]
 
 - name: Final clean
   import_tasks: final_clean.yml
-  tags: [create_target_vm, final_clean, never]
+  tags: [final_clean, never]
 
 
 - name: Validate network interface


### PR DESCRIPTION
When using `hosted-engine --deploy`, "Sync on engine machine" and
"Final clean" tasks run twice, once at the end of "Creating Target VM" stage
and right after that in "Cleaning temporary resources" stage.
This PR removes these tasks from "Creating Target VM" stage,
therefore they will be executed only in the "Final clean" stage.

Bug-Url: https://bugzilla.redhat.com/1977486
Signed-off-by: Asaf Rachmani <arachman@redhat.com>