### PR TITLE
roles: hosted_engine_setup: Use forward network during an IPv6 deployment

### DIFF
--- a/changelogs/fragments/315-use-forward-netrok-during-ipv6-deployment.yml
+++ b/changelogs/fragments/315-use-forward-netrok-during-ipv6-deployment.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Use forward network during an IPv6 deployment (https://github.com/oVirt/ovirt-ansible-collection/pull/315)

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -14,7 +14,7 @@
         xpath: /network/ip
         state: absent
       register: editednet_noipv4
-    - name: Configure libvirt default network as an forward network
+    - name: Configure libvirt default network as a forward network
       xml:
         xmlstring: "{{ editednet_noipv4.xmlstring }}"
         xpath: /network/forward

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -6,21 +6,37 @@
   register: default_net_xml
 - name: IPv6 configuration
   block:
+    - name: Accept IPv6 Router Advertisements
+      shell: echo 2 > /proc/sys/net/ipv6/conf/ovirtmgmt/accept_ra
     - name: Remove IPv4 configuration
       xml:
         xmlstring: "{{ default_net_xml.get_xml }}"
         xpath: /network/ip
         state: absent
       register: editednet_noipv4
-    - name: Configure it as an isolated network
+    - name: Configure libvirt default network as an forward network
       xml:
         xmlstring: "{{ editednet_noipv4.xmlstring }}"
         xpath: /network/forward
-        state: absent
-      register: editednet_isolated
+        state: present
+      register: editednet_forward
+    - name: Edit libvirt default network configuration, enable NAT
+      xml:
+        xmlstring: "{{ editednet_forward.xmlstring }}"
+        xpath: /network/forward
+        attribute: mode
+        value: "nat"
+      register: editednet_nat
+    - name: Edit libvirt default network configuration, enable NAT IPv6
+      xml:
+        xmlstring: "{{ editednet_nat.xmlstring }}"
+        xpath: /network/forward/nat
+        attribute: ipv6
+        value: "yes"
+      register: editednet_natipv6
     - name: Edit libvirt default network configuration, set IPv6 address
       xml:
-        xmlstring: "{{ editednet_isolated.xmlstring }}"
+        xmlstring: "{{ editednet_natipv6.xmlstring }}"
         xpath: /network/ip[@family='ipv6']
         attribute: address
         value: "{{ he_ipv6_subnet_prefix + '::1' }}"


### PR DESCRIPTION
Use forward network instead of isolated network
during an IPv6 deployment

Bug-Url: https://bugzilla.redhat.com/1947709
Signed-off-by: Asaf Rachmani <arachman@redhat.com>