### PR TITLE
ovirt_permission: fix group search that has space in it's name

### DIFF
--- a/changelogs/fragments/318-ovirt_permission-fix-group-search-that-has-space.yml
+++ b/changelogs/fragments/318-ovirt_permission-fix-group-search-that-has-space.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_permission - fix group search that has space in it's name (https://github.com/oVirt/ovirt-ansible-collection/pull/318)

--- a/plugins/modules/ovirt_permission.py
+++ b/plugins/modules/ovirt_permission.py
@@ -226,7 +226,7 @@ class PermissionsModule(BaseModule):
 
     def _group(self):
         groups = self._connection.system_service().groups_service().list(
-            search="name={name}".format(
+            search='name="{name}"'.format(
                 name=self._module.params['group_name'],
             )
         )


### PR DESCRIPTION
Currently if we try to add a group with space to any object, it will fails with error "Group was not found". This fixes the same.

RHBZ: https://bugzilla.redhat.com/1982058