### PR TITLE
roles: hosted_engine_setup: update Ansible requirements

### DIFF
--- a/changelogs/fragments/321-hosted_engine_setup-update-ansible-requirements-in-readme.yml
+++ b/changelogs/fragments/321-hosted_engine_setup-update-ansible-requirements-in-readme.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - Update Ansible requirements in README (https://github.com/oVirt/ovirt-ansible-collection/pull/321)

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -2,6 +2,10 @@
 
 Ansible role for deploying oVirt Hosted-Engine
 
+# Requirements
+
+Ansible version >= 2.9.21 and < 2.10.0
+
 # Prerequisites
 
 * A fully qualified domain name prepared for your Engine and the host. Forward and reverse lookup records must both be set in the DNS.


### PR DESCRIPTION
Following a change in ovirt-hosted-engine-setup [1]
and addressing https://github.com/oVirt/ovirt-ansible-collection/issues/240

[1] https://gerrit.ovirt.org/#/c/ovirt-hosted-engine-setup/+/115113/1/ovirt-hosted-engine-setup.spec.in

Signed-off-by: Asaf Rachmani <arachman@redhat.com>