### PR TITLE
engine_setup: wait after engine-config reboot

### DIFF
--- a/changelogs/fragments/324-engine_setup-wait-for-engine-config-reboot.yml
+++ b/changelogs/fragments/324-engine_setup-wait-for-engine-config-reboot.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - engine_setup - Wait for webserver up after engine-config reboot (https://github.com/oVirt/ovirt-ansible-collection/pull/324).

--- a/roles/engine_setup/tasks/engine_setup.yml
+++ b/roles/engine_setup/tasks/engine_setup.yml
@@ -91,15 +91,6 @@
       name: ovirt-engine
       state: started
 
-  - name: Check if Engine health page is up
-    uri:
-      url: "http://localhost/ovirt-engine/services/health"
-      status_code: 200
-    register: health_page
-    retries: 30
-    delay: 10
-    until: health_page is success
-
   - name: Run engine-config
     command: "engine-config -s {{ item.key }}='{{ item.value }}' {% if item.version is defined %} --cver={{ item.version }} {% endif %}"
     loop: "{{ ovirt_engine_setup_engine_configs | default([]) }}"
@@ -109,6 +100,15 @@
       name: ovirt-engine
       state: restarted
     when: ovirt_engine_setup_engine_configs is defined
+
+  - name: Check if Engine health page is up
+    uri:
+      url: "http://localhost/ovirt-engine/services/health"
+      status_code: 200
+    register: health_page
+    retries: 30
+    delay: 10
+    until: health_page is success
 
   always:
     - name: Clean temporary files


### PR DESCRIPTION
Issue: when immediately after engine_setup someone tries to access the web server it is not available because it is starting 