### PR TITLE
ovirt_auth: fix token no_log

### DIFF
--- a/changelogs/fragments/332-ovirt_auth-fix-token-no_log.yml
+++ b/changelogs/fragments/332-ovirt_auth-fix-token-no_log.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_auth - Fix token no_log (https://github.com/oVirt/ovirt-ansible-collection/pull/332).

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -423,7 +423,6 @@ def __get_auth_dict():
             token=dict(
                 type='str',
                 fallback=(env_fallback, ['OVIRT_TOKEN']),
-                no_log=True,
             ),
             ca_file=dict(
                 type='str',

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -423,6 +423,7 @@ def __get_auth_dict():
             token=dict(
                 type='str',
                 fallback=(env_fallback, ['OVIRT_TOKEN']),
+                no_log=False,
             ),
             ca_file=dict(
                 type='str',

--- a/plugins/modules/ovirt_auth.py
+++ b/plugins/modules/ovirt_auth.py
@@ -234,7 +234,7 @@ def main():
             kerberos=dict(required=False, type='bool', default=False),
             headers=dict(required=False, type='dict'),
             state=dict(default='present', choices=['present', 'absent']),
-            token=dict(default=None, no_log=True),
+            token=dict(default=None, no_log=False),
             ovirt_auth=dict(required=False, type='dict'),
         ),
         required_if=[


### PR DESCRIPTION
Issue: when passing the already preheated token the ansible filters the value even for other tasks so the auth immediately fails. 