### PR TITLE
roles: add ssh key to remove stale LUN example

### DIFF
--- a/changelogs/fragments/334-remove_stale_lun-role.yml
+++ b/changelogs/fragments/334-remove_stale_lun-role.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - remove_stale_lun - Fix example for `remote_stale_lun` role to be able to run it from engine (https://github.com/oVirt/ovirt-ansible-collection/pull/334).

--- a/roles/remove_stale_lun/README.md
+++ b/roles/remove_stale_lun/README.md
@@ -2,7 +2,8 @@ oVirt Remove Stale LUN
 =========
 
 The `remove_stale_lun` role iterates through all the hosts in a data center and remove stale LUN devices from these hosts.
-If the playbook is not executed on the engine, user ssh key has to be added on all hosts which belongs to the given data center.
+Example playbook uses engine private ssh key for connection to the hosts and therefore assumes it's executed from the engine machine.
+If the playbook is not executed on the engine, user ssh key has to be added on all hosts which belongs to the given data center or the user has to provide appropriate inventory file.
 
 Role Variables
 --------------
@@ -28,6 +29,10 @@ Example Playbook
     - passwords.yml
 
   vars:
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+    ansible_user: root
+    ansible_ssh_private_key_file: /etc/pki/ovirt-engine/keys/engine_id_rsa
+
     engine_fqdn: ovirt.example.com
     engine_user: admin@internal
 

--- a/roles/remove_stale_lun/examples/remove_stale_lun.yml
+++ b/roles/remove_stale_lun/examples/remove_stale_lun.yml
@@ -9,6 +9,10 @@
     - passwords.yml
 
   vars:
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+    ansible_user: root
+    ansible_ssh_private_key_file: /etc/pki/ovirt-engine/keys/engine_id_rsa
+    
     engine_fqdn: ovirt.example.com
     engine_user: admin@internal
 


### PR DESCRIPTION
Add engine ssh key and other relevant ssh connection variable to remove
stale LUN example, so that example can be run from the engine. Update
also README file.