### PR TITLE
automation: enable c9s build

### DIFF
--- a/automation.yml
+++ b/automation.yml
@@ -1,8 +1,11 @@
 ---
 distros:
   - el8
+  - el9stream:
+      runtime-requirements:
+        host_distro: newer
 release_branches:
-  master: [ "ovirt-master" ]
+  master: ["ovirt-master"]
 stages:
   - build-artifacts:
       substages:

--- a/automation/build-artifacts-manual.ansible-core.repos.el9stream
+++ b/automation/build-artifacts-manual.ansible-core.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/build-artifacts-manual.ansible.repos.el9stream
+++ b/automation/build-artifacts-manual.ansible.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/build-artifacts.ansible-core.repos.el9stream
+++ b/automation/build-artifacts.ansible-core.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/build-artifacts.ansible.repos.el9stream
+++ b/automation/build-artifacts.ansible.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/build-artifacts.repos.el9stream
+++ b/automation/build-artifacts.repos.el9stream
@@ -1,0 +1,1 @@
+el9collection,https://download.copr.fedorainfracloud.org/results/sbonazzo/EL9Collection/centos-stream-9-$basearch/

--- a/automation/check-merged.repos.el9stream
+++ b/automation/check-merged.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/check-patch.ansible-core.repos.el9stream
+++ b/automation/check-patch.ansible-core.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream

--- a/automation/check-patch.ansible.repos.el9stream
+++ b/automation/check-patch.ansible.repos.el9stream
@@ -1,0 +1,1 @@
+build-artifacts.repos.el9stream


### PR DESCRIPTION
Enable CentOS Stream 9 builds and provide repos for
missing rpm dependencies.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>