### PR TITLE
roles: hosted_engine_setup: Use `he_iscsi_tpgt` variable for iscsi login

### DIFF
--- a/changelogs/fragments/338-use-tpgt-in-iscsi-login.yml
+++ b/changelogs/fragments/338-use-tpgt-in-iscsi-login.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Use tpgt in iscsi login (https://github.com/oVirt/ovirt-ansible-collection/pull/338)

--- a/roles/hosted_engine_setup/tasks/iscsi_getdevices.yml
+++ b/roles/hosted_engine_setup/tasks/iscsi_getdevices.yml
@@ -11,6 +11,7 @@
       address: "{{ item.0 }}"
       port: "{{ item.1 }}"
       target: "{{ he_iscsi_target }}"
+      portal: "{{ he_iscsi_tpgt | default(omit) }}"
     auth: "{{ ovirt_auth }}"
   no_log: true
   ignore_errors: true


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/1768969
Signed-off-by: Asaf Rachmani <arachman@redhat.com>