### PR TITLE
Replacing gluster module to CLI to support RHV automation hub

### DIFF
--- a/changelogs/fragments/340-replace-gluster-module-to-cli.yml
+++ b/changelogs/fragments/340-replace-gluster-module-to-cli.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gluster_heal_info - Replacing gluster module to CLI to support RHV automation hub (https://github.com/oVirt/ovirt-ansible-collection/pull/340).

--- a/roles/cluster_upgrade/tasks/upgrade.yml
+++ b/roles/cluster_upgrade/tasks/upgrade.yml
@@ -50,8 +50,8 @@
   retries: "{{ healing_in_progress_checks }}"
   delay: "{{ healing_in_progress_check_delay }}"
   until: >
-     self_heal_status.stdout is defined and
-     self_heal_status.stdout | map(attribute='no_of_entries') | select('defined') | list | map('int') | sum == 0
+     self_heal_status.stdout_lines is defined and
+     self_heal_status.stdout_lines | select('match','^(Number of entries: )[0-9]+') | map('last') | map('int') | sum == 0
   delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
   connection: ssh
   with_items:

--- a/roles/cluster_upgrade/tasks/upgrade.yml
+++ b/roles/cluster_upgrade/tasks/upgrade.yml
@@ -45,15 +45,13 @@
       - description: "Upgrading host: {{ item.name }}"
 
 - name: Gather self-heal facts about all gluster hosts in the cluster
-  gluster_heal_info:
-    name: "{{ volume_item.name }}"
-    status_filter: self-heal
+  ansible.builtin.shell: gluster volume heal {{ volume_item.name }} info
   register: self_heal_status
   retries: "{{ healing_in_progress_checks }}"
   delay: "{{ healing_in_progress_check_delay }}"
   until: >
-     self_heal_status is defined and
-     self_heal_status.glusterfs.heal_info | map(attribute='no_of_entries') | select('defined') | list | map('int') | sum == 0
+     self_heal_status.stdout is defined and
+     self_heal_status.stdout | map(attribute='no_of_entries') | select('defined') | list | map('int') | sum == 0
   delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
   connection: ssh
   with_items:


### PR DESCRIPTION
Replacing gluster module to CLI to support RHV automation hub