### PR TITLE
replace redhat_subscription and rhsm_repository with command

### DIFF
--- a/changelogs/fragments/346-repositories-replace-redhat_subscription-and-rhsm_repository-with-command.yml
+++ b/changelogs/fragments/346-repositories-replace-redhat_subscription-and-rhsm_repository-with-command.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - repositories - Replace redhat_subscription and rhsm_repository with command (https://github.com/oVirt/ovirt-ansible-collection/pull/346).

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -25,6 +25,7 @@
     --password {{ ovirt_repositories_rh_password }}
     {% if ovirt_repositories_force_register is defined %} --force {% endif %}
     {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ ovirt_repositories_rhsm_server_hostname }} {% endif %}
+  changed_when: false
 
 - include_tasks: search-pool-id.yml
   with_items:

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -18,40 +18,27 @@
     name: subscription-manager
     state: present
 
-- name: Register and subscribe to multiple pool IDs
-  redhat_subscription:
-    state: present
-    force_register: "{{ ovirt_repositories_force_register }}"
-    username: "{{ ovirt_repositories_rh_username | mandatory }}"
-    password: "{{ ovirt_repositories_rh_password | mandatory }}"
-    pool_ids: "{{ ovirt_repositories_pool_ids }}"
-    server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
-  when: ovirt_repositories_pool_ids is defined
+- name: Register to subscription manager
+  command: subscription-manager register --username {{ ovirt_repositories_rh_username }} --password {{ ovirt_repositories_rh_password }} {% if ovirt_repositories_force_register is defined %} --force {% endif %} {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ovirt_repositories_rhsm_server_hostname}} {% endif %}
 
-- name: Register to and subscribe to pool
-  redhat_subscription:
-    state: present
-    force_register: "{{ ovirt_repositories_force_register }}"
-    username: "{{ ovirt_repositories_rh_username | mandatory }}"
-    password: "{{ ovirt_repositories_rh_password | mandatory }}"
-    pool: "^({{ ovirt_repositories_pools | list | map('regex_escape') | join(')$|^(') }})$"
-    server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
-  when: ovirt_repositories_pools is defined
+- include_tasks: search-pool-id.yml
+  with_items:
+    - "{{ ovirt_repositories_pools }}"
+
+- name: Subscribe to multiple pool IDs
+  command: subscription-manager attach {% for id in ovirt_repositories_pool_ids %} --pool {{ id }} {% endfor %}
+  when: ovirt_repositories_pool_ids is defined and ovirt_repositories_pool_ids | list | length != 0
 
 - name: "Include {{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml variables"
   include_vars: "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
   when: ovirt_repositories_subscription_manager_repos | list | length == 0
 
 - name: Disable all repositories
-  rhsm_repository:
-    state: absent
-    name: "*"
+  command: subscription-manager repos --disable=*
   when: ovirt_repositories_clear
 
 - name: Enable required repositories
-  rhsm_repository:
-    name: "{{ item }}"
-    state: "enabled"
+  command: subscription-manager repos --enable={{ item }}
   with_items: "{{ ovirt_repositories_subscription_manager_repos }}"
 
 - name: Enable dnf modules

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -30,6 +30,7 @@
 - include_tasks: search-pool-id.yml
   with_items:
     - "{{ ovirt_repositories_pools }}"
+  when: ovirt_repositories_pools is defined
 
 - name: Subscribe to multiple pool IDs
   command: subscription-manager attach {% for id in ovirt_repositories_pool_ids %} --pool {{ id }} {% endfor %}

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -19,7 +19,12 @@
     state: present
 
 - name: Register to subscription manager
-  command: subscription-manager register --username {{ ovirt_repositories_rh_username }} --password {{ ovirt_repositories_rh_password }} {% if ovirt_repositories_force_register is defined %} --force {% endif %} {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ovirt_repositories_rhsm_server_hostname}} {% endif %}
+  command: |
+    subscription-manager register
+    --username {{ ovirt_repositories_rh_username }}
+    --password {{ ovirt_repositories_rh_password }}
+    {% if ovirt_repositories_force_register is defined %} --force {% endif %}
+    {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ovirt_repositories_rhsm_server_hostname}} {% endif %}
 
 - include_tasks: search-pool-id.yml
   with_items:

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -24,7 +24,7 @@
     --username {{ ovirt_repositories_rh_username }}
     --password {{ ovirt_repositories_rh_password }}
     {% if ovirt_repositories_force_register is defined %} --force {% endif %}
-    {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ovirt_repositories_rhsm_server_hostname}} {% endif %}
+    {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ ovirt_repositories_rhsm_server_hostname }} {% endif %}
 
 - include_tasks: search-pool-id.yml
   with_items:
@@ -44,6 +44,7 @@
 
 - name: Enable required repositories
   command: subscription-manager repos --enable={{ item }}
+  changed_when: false
   with_items: "{{ ovirt_repositories_subscription_manager_repos }}"
 
 - name: Enable dnf modules

--- a/roles/repositories/tasks/search-pool-id.yml
+++ b/roles/repositories/tasks/search-pool-id.yml
@@ -1,6 +1,7 @@
 ---
 - name: Search pool ID for '{{ item }}'
-  shell: subscription-manager list --available --pool-only --matches="{{ item }}"
+  command: subscription-manager list --available --pool-only --matches="{{ item }}"
+  changed_when: false
   register: availible_pool
 
 - name: Search pool ID for '{{ item }}'

--- a/roles/repositories/tasks/search-pool-id.yml
+++ b/roles/repositories/tasks/search-pool-id.yml
@@ -1,0 +1,18 @@
+---
+- name: Search pool ID for '{{ item }}'
+  command: subscription-manager list --available --pool-only --matches="{{ item }}"
+  register: availible_pool
+
+- name: Search pool ID for '{{ item }}'
+  command: subscription-manager list --consumed --pool-only --matches="{{ item }}"
+  register: consumed_pool
+  when: availible_pool['stdout_lines'] | list | length == 0
+
+- name: Fail when could not find pool '{{ item }}' 
+  fail:
+    msg: The pool '{{ item }}' could not be found. 
+  when: availible_pool['stdout_lines'] | list | length == 0 and consumed_pool['stdout_lines'] | list | length == 0
+
+- name: Attach searched pool ids to ovirt_repositories_pool_ids 
+  set_fact:
+    ovirt_repositories_pool_ids: "{{ availible_pool['stdout_lines'] + ovirt_repositories_pool_ids | default([]) }}"

--- a/roles/repositories/tasks/search-pool-id.yml
+++ b/roles/repositories/tasks/search-pool-id.yml
@@ -1,6 +1,6 @@
 ---
 - name: Search pool ID for '{{ item }}'
-  command: subscription-manager list --available --pool-only --matches="{{ item }}"
+  shell: subscription-manager list --available --pool-only --matches="{{ item }}"
   register: availible_pool
 
 - name: Search pool ID for '{{ item }}'
@@ -8,11 +8,11 @@
   register: consumed_pool
   when: availible_pool['stdout_lines'] | list | length == 0
 
-- name: Fail when could not find pool '{{ item }}' 
+- name: Fail when could not find pool '{{ item }}'
   fail:
-    msg: The pool '{{ item }}' could not be found. 
+    msg: The pool '{{ item }}' could not be found.
   when: availible_pool['stdout_lines'] | list | length == 0 and consumed_pool['stdout_lines'] | list | length == 0
 
-- name: Attach searched pool ids to ovirt_repositories_pool_ids 
+- name: Attach searched pool ids to ovirt_repositories_pool_ids
   set_fact:
     ovirt_repositories_pool_ids: "{{ availible_pool['stdout_lines'] + ovirt_repositories_pool_ids | default([]) }}"


### PR DESCRIPTION
The downstream ansible execution environment does not contain any community collection.
(The `redhat_subscription` and `rhsm_repository` are in the community collections)
We need to switch to some other solution from the modules to make it compatible with the execution environment.