### PR TITLE
ovirt_remove_stale_lun: Allow user to remove multiple LUNs

### DIFF
--- a/changelogs/fragments/351-ovirt_remove_stale_lun-allow-user-to-remove-multiple-luns.yml
+++ b/changelogs/fragments/351-ovirt_remove_stale_lun-allow-user-to-remove-multiple-luns.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ovirt_remove_stale_lun - Allow user to remove multiple LUNs (https://github.com/oVirt/ovirt-ansible-collection/pull/357).

--- a/roles/remove_stale_lun/README.md
+++ b/roles/remove_stale_lun/README.md
@@ -11,7 +11,7 @@ Role Variables
 | Name                    | Default value         |                                                     |
 |-------------------------|-----------------------|-----------------------------------------------------|
 | data_center             | Default               | Name of the data center from which hosts stale LUN should be removed. |
-| lun_wwid                | UNDEF                 | WWID of the stale LUN which should be removed from the hosts. |
+| lun_wwid                | UNDEF                 | WWID of the stale LUN(s) which should be removed from the hosts. Separate multiple LUNs with spaces. |
 
 
 Example Playbook
@@ -37,7 +37,7 @@ Example Playbook
     engine_user: admin@internal
 
     data_center: default
-    lun_wwid: 36001405a77a1ee25cbf4439b7ddd2062
+    lun_wwid: 36001405a77a1ee25cbf4439b7ddd2062 36001405ddefe8392bb8443e89bde4b40
 
   roles:
     - remove_stale_lun

--- a/roles/remove_stale_lun/examples/remove_stale_lun.yml
+++ b/roles/remove_stale_lun/examples/remove_stale_lun.yml
@@ -17,7 +17,7 @@
     engine_user: admin@internal
 
     data_center: default
-    lun_wwid: 36001405a77a1ee25cbf4439b7ddd2062
+    lun_wwid: 36001405a77a1ee25cbf4439b7ddd2062 36001405ddefe8392bb8443e89bde4b40
 
   roles:
     - remove_stale_lun

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -1,5 +1,5 @@
-- name: Get underlying disks (paths) for a multipath device and turn them into a list.
-  ansible.builtin.shell: dmsetup deps -o devname "{{ lun_wwid }}" | cut -f 2 |cut -c 3- |tr -d "()"
+- name: Get underlying disks (paths) for a multipath device(s) and turn them into a list.
+  ansible.builtin.shell: 'for dev in {{ lun_wwid }}; do dmsetup deps -o devname $dev | cut -f 2 |cut -c 3- |tr -d "()"|tr "\r\n" " "; done'
   register: disks
   delegate_to: "{{ host_item.address }}"
   connection: ssh
@@ -10,7 +10,7 @@
     loop_var: host_item
 
 - name: Remove from multipath device.
-  ansible.builtin.shell: multipath -f "{{ lun_wwid }}"
+  ansible.builtin.shell: "for dev in {{ lun_wwid }}; do multipath -f $dev; done"
   delegate_to: "{{ host_item.address }}"
   connection: ssh
   check_mode: "no"


### PR DESCRIPTION
Currently, if a user has to remove multiple LUNs, they have to run
the playbook individually for each LUNs. This is not that user
friendly if the user has to remove many LUNs. This commit provides
option to pass multiple LUNs.