### PR TITLE
roles: hosted_engine_setup: replace virt_net and xml with commands

### DIFF
--- a/changelogs/fragments/359-he-replace-virt_net-and-xml-with-commands.yml
+++ b/changelogs/fragments/359-he-replace-virt_net-and-xml-with-commands.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine - Replace virt_net and xml with commands (https://github.com/oVirt/ovirt-ansible-collection/pull/359).

--- a/plugins/filter/ovirtvmip.py
+++ b/plugins/filter/ovirtvmip.py
@@ -23,7 +23,7 @@ class FilterModule(object):
             'filtervalue': self.filtervalue,
             'removesensitivevmdata': self.removesensitivevmdata,
             'ovirtdiff': self.ovirtdiff,
-            'get_bridge_xml_to_dict': self.get_bridge_xml_to_dict,
+            'get_network_xml_to_dict': self.get_network_xml_to_dict,
         }
 
     def ovirtdiff(self, vm1, vm2):
@@ -148,9 +148,12 @@ class FilterModule(object):
                     profile['sysprep'][key_to_remove] = "******"
         return data
 
-    def get_bridge_xml_to_dict(self, data):
+    def get_network_xml_to_dict(self, data):
         tree = ElementTree.fromstring(data)
+        resp = {}
         for child in tree:
             if child.tag == 'bridge':
-                return child.attrib
-        return None
+                resp['bridge'] = child.attrib
+            if child.tag == 'uuid':
+                resp['uuid'] = child.text
+        return resp

--- a/plugins/filter/ovirtvmip.py
+++ b/plugins/filter/ovirtvmip.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 
 import socket
 import struct
+from xml.etree import ElementTree
 
 
 class FilterModule(object):
@@ -22,6 +23,7 @@ class FilterModule(object):
             'filtervalue': self.filtervalue,
             'removesensitivevmdata': self.removesensitivevmdata,
             'ovirtdiff': self.ovirtdiff,
+            'get_bridge_xml_to_dict': self.get_bridge_xml_to_dict,
         }
 
     def ovirtdiff(self, vm1, vm2):
@@ -145,3 +147,10 @@ class FilterModule(object):
                 if 'sysprep' in profile and key_to_remove in profile['sysprep']:
                     profile['sysprep'][key_to_remove] = "******"
         return data
+
+    def get_bridge_xml_to_dict(self, data):
+        tree = ElementTree.fromstring(data)
+        for child in tree:
+            if child.tag == 'bridge':
+                return child.attrib
+        return None

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -1,108 +1,24 @@
 ---
 - name: Parse libvirt default network configuration
-  virt_net:
-    command: get_xml
-    name: default
+  command: virsh net-dumpxml default
   register: default_net_xml
-- name: IPv6 configuration
-  block:
-    - name: Remove IPv4 configuration
-      xml:
-        xmlstring: "{{ default_net_xml.get_xml }}"
-        xpath: /network/ip
-        state: absent
-      register: editednet_noipv4
-    - name: Configure libvirt default network as a forward network
-      xml:
-        xmlstring: "{{ editednet_noipv4.xmlstring }}"
-        xpath: /network/forward
-        state: present
-      register: editednet_forward
-    - name: Edit libvirt default network configuration, enable NAT
-      xml:
-        xmlstring: "{{ editednet_forward.xmlstring }}"
-        xpath: /network/forward
-        attribute: mode
-        value: "nat"
-      register: editednet_nat
-    - name: Edit libvirt default network configuration, enable NAT IPv6
-      xml:
-        xmlstring: "{{ editednet_nat.xmlstring }}"
-        xpath: /network/forward/nat
-        attribute: ipv6
-        value: "yes"
-      register: editednet_natipv6
-    - name: Edit libvirt default network configuration, set IPv6 address
-      xml:
-        xmlstring: "{{ editednet_natipv6.xmlstring }}"
-        xpath: /network/ip[@family='ipv6']
-        attribute: address
-        value: "{{ he_ipv6_subnet_prefix + '::1' }}"
-      register: editednet1
-    - name: Edit libvirt default network configuration, set IPv6 prefix
-      xml:
-        xmlstring: "{{ editednet1.xmlstring }}"
-        xpath: /network/ip[@family='ipv6']
-        attribute: prefix
-        value: "64"
-      register: editednet2
-    - name: Edit libvirt default network configuration, enable DHCPv6
-      xml:
-        xmlstring: "{{ editednet2.xmlstring }}"
-        xpath: /network/ip[@family='ipv6']/dhcp/range
-        attribute: start
-        value: "{{ he_ipv6_subnet_prefix + '::10' }}"
-      register: editednet3
-    - name: Edit libvirt default network configuration, set DHCPv6 range
-      xml:
-        xmlstring: "{{ editednet3.xmlstring }}"
-        xpath: /network/ip[@family='ipv6']/dhcp/range
-        attribute: end
-        value: "{{ he_ipv6_subnet_prefix + '::ff' }}"
-      register: finaledit6
-  when: ipv6_deployment|bool
 
-- name: IPv4 configuration
-  block:
-    - name: Edit libvirt default network configuration, change default address
-      xml:
-        xmlstring: "{{ default_net_xml.get_xml }}"
-        xpath: /network/ip
-        attribute: address
-        value: "{{ he_ipv4_subnet_prefix + '.1' }}"
-      register: editednet1
-    - name: Edit libvirt default network configuration, change DHCP start range
-      xml:
-        xmlstring: "{{ editednet1.xmlstring }}"
-        xpath: /network/ip/dhcp/range
-        attribute: start
-        value: "{{ he_ipv4_subnet_prefix + '.2' }}"
-      register: editednet2
-    - name: Edit libvirt default network configuration, change DHCP end range
-      xml:
-        xmlstring: "{{ editednet2.xmlstring }}"
-        xpath: /network/ip/dhcp/range
-        attribute: end
-        value: "{{ he_ipv4_subnet_prefix + '.254' }}"
-      register: finaledit4
-  when: not ipv6_deployment|bool
+- set_fact:
+    bridge_dict: "{{ default_net_xml['stdout'] | ovirt.ovirt.get_bridge_xml_to_dict }}"
+
+- template:
+    src: templates/network-config.j2
+    dest: /tmp/he-network-config.xml
 
 - name: Update libvirt default network configuration, destroy
-  virt_net:
-    command: destroy
-    name: default
+  command: virsh net-destroy default
+
 - name: Update libvirt default network configuration, undefine
-  virt_net:
-    command: undefine
-    name: default
+  command: virsh net-undefine default
   ignore_errors: true
+
 - name: Update libvirt default network configuration, define
-  virt_net:
-    command: define
-    name: default
-    xml: "{{ finaledit6.xmlstring if ipv6_deployment else finaledit4.xmlstring }}"
+  command: virsh net-define --file /tmp/he-network-config.xml
+
 - name: Activate default libvirt network
-  virt_net:
-    name: default
-    state: active
-  register: virt_net_out
+  command: virsh net-start default

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -4,9 +4,9 @@
   changed_when: false
   register: default_net_xml
 
-- name: Set bridge_dict from default_net_xml
+- name: Set network_dict from default_net_xml
   set_fact:
-    bridge_dict: "{{ default_net_xml['stdout'] | ovirt.ovirt.get_bridge_xml_to_dict }}"
+    network_dict: "{{ default_net_xml['stdout'] | ovirt.ovirt.get_network_xml_to_dict }}"
 
 - name: Create he-network-config.xml from network-config.j2 template
   template:

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -1,6 +1,7 @@
 ---
 - name: Parse libvirt default network configuration
   command: virsh net-dumpxml default
+  changed_when: false
   register: default_net_xml
 
 - set_fact:
@@ -12,13 +13,17 @@
 
 - name: Update libvirt default network configuration, destroy
   command: virsh net-destroy default
+  changed_when: false
 
 - name: Update libvirt default network configuration, undefine
   command: virsh net-undefine default
   ignore_errors: true
+  changed_when: false
 
 - name: Update libvirt default network configuration, define
   command: virsh net-define --file /tmp/he-network-config.xml
+  changed_when: false
 
 - name: Activate default libvirt network
   command: virsh net-start default
+  changed_when: false

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -16,6 +16,7 @@
 
 - name: Update libvirt default network configuration, destroy
   command: virsh net-destroy default
+  ignore_errors: true
   changed_when: false
 
 - name: Update libvirt default network configuration, undefine

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -4,12 +4,15 @@
   changed_when: false
   register: default_net_xml
 
-- set_fact:
+- name: Set bridge_dict from default_net_xml
+  set_fact:
     bridge_dict: "{{ default_net_xml['stdout'] | ovirt.ovirt.get_bridge_xml_to_dict }}"
 
-- template:
+- name: Create he-network-config.xml from network-config.j2 template
+  template:
     src: templates/network-config.j2
     dest: /tmp/he-network-config.xml
+    mode: 0644
 
 - name: Update libvirt default network configuration, destroy
   command: virsh net-destroy default

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
@@ -20,7 +20,7 @@
       enabled: true
   - name: Activate default libvirt network
     command: virsh net-autostart default
-    change_when: false
+    changed_when: false
   - name: Get routing rules, IPv4
     command: ip -j rule
     environment: "{{ he_cmd_lang }}"

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
@@ -19,13 +19,8 @@
       state: started
       enabled: true
   - name: Activate default libvirt network
-    virt_net:
-      name: default
-      state: active
-    register: virt_net_out
-  - name: Get libvirt interfaces
-    virt_net:
-      command: facts
+    command: virsh net-autostart default
+    change_when: false
   - name: Get routing rules, IPv4
     command: ip -j rule
     environment: "{{ he_cmd_lang }}"
@@ -39,7 +34,7 @@
     when: ipv6_deployment|bool
   - name: Save bridge name
     set_fact:
-      virbr_default: "{{ ansible_libvirt_networks['default']['bridge'] }}"
+      virbr_default: "{{ network_dict['bridge']['name'] }}"
   - name: Wait for the bridge to appear on the host
     command: ip link show {{ virbr_default }}
     environment: "{{ he_cmd_lang }}"

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/01_prepare_routing_rules.yml
@@ -20,6 +20,7 @@
       enabled: true
   - name: Activate default libvirt network
     command: virsh net-autostart default
+    ignore_errors: true
     changed_when: false
   - name: Get routing rules, IPv4
     command: ip -j rule

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -7,14 +7,14 @@
     </nat>
   </forward>
   <bridge name='{{ network_dict['bridge']['name'] }}' stp='{{ network_dict['bridge']['stp'] }}' delay='{{ network_dict['bridge']['delay'] }}'/>
-{% if he_ipv6_subnet_prefix is defined %}
+{% if not he_force_ip4 he_ipv6_subnet_prefix is defined %}
   <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>
     <dhcp>
       <range start='{{ he_ipv6_subnet_prefix + '::10' }}' end='{{ he_ipv6_subnet_prefix + '::ff' }}'/>
     </dhcp>
   </ip>
 {% endif %}
-{% if he_ipv4_subnet_prefix is defined %}
+{% if not he_force_ip6 and he_ipv4_subnet_prefix is defined %}
   <ip address='{{ he_ipv4_subnet_prefix + '.1' }}' netmask='255.255.255.0'>
     <dhcp>
       <range start='{{ he_ipv4_subnet_prefix + '.2' }}' end='{{ he_ipv4_subnet_prefix + '.254' }}'/>

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -1,0 +1,25 @@
+<network>
+  <name>default</name>
+  <uuid>e672dfa7-3d1d-4e10-a639-0779d44431aa</uuid>
+  <forward mode='nat'>
+    <nat {% if he_ipv6_subnet_prefix is defined %}ipv6='yes' {% endif %}>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <mac address='52:54:00:78:d7:dc'/>
+  <bridge name='{{ bridge_dict['name'] }}' stp='{{ bridge_dict['stp'] }}' delay='{{ bridge_dict['delay'] }}'/>
+{% if he_ipv6_subnet_prefix is defined %}
+  <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>
+    <dhcp>
+      <range start='{{ he_ipv6_subnet_prefix + '::10' }}' end='{{ he_ipv6_subnet_prefix + '::ff' }}'/>
+    </dhcp>
+  </ip>
+{% endif %}
+{% if he_ipv4_subnet_prefix is defined %}
+  <ip address='{{ he_ipv4_subnet_prefix + '.1' }}' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='{{ he_ipv4_subnet_prefix + '.2' }}' end='{{ he_ipv4_subnet_prefix + '.254' }}'/>
+    </dhcp>
+  </ip>
+{% endif %}
+</network>

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -1,13 +1,13 @@
 <network>
   <name>default</name>
-  <uuid>e672dfa7-3d1d-4e10-a639-0779d44431aa</uuid>
+  <uuid>{{ network_dict['uuid'] }}</uuid>
   <forward mode='nat'>
     <nat {% if he_ipv6_subnet_prefix is defined %}ipv6='yes' {% endif %}>
       <port start='1024' end='65535'/>
     </nat>
   </forward>
   <mac address='52:54:00:78:d7:dc'/>
-  <bridge name='{{ bridge_dict['name'] }}' stp='{{ bridge_dict['stp'] }}' delay='{{ bridge_dict['delay'] }}'/>
+  <bridge name='{{ network_dict['bridge']['name'] }}' stp='{{ network_dict['bridge']['stp'] }}' delay='{{ network_dict['bridge']['delay'] }}'/>
 {% if he_ipv6_subnet_prefix is defined %}
   <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>
     <dhcp>

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -6,7 +6,6 @@
       <port start='1024' end='65535'/>
     </nat>
   </forward>
-  <mac address='52:54:00:78:d7:dc'/>
   <bridge name='{{ network_dict['bridge']['name'] }}' stp='{{ network_dict['bridge']['stp'] }}' delay='{{ network_dict['bridge']['delay'] }}'/>
 {% if he_ipv6_subnet_prefix is defined %}
   <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -7,7 +7,7 @@
     </nat>
   </forward>
   <bridge name='{{ network_dict['bridge']['name'] }}' stp='{{ network_dict['bridge']['stp'] }}' delay='{{ network_dict['bridge']['delay'] }}'/>
-{% if not he_force_ip4 he_ipv6_subnet_prefix is defined %}
+{% if not he_force_ip4 and he_ipv6_subnet_prefix is defined %}
   <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>
     <dhcp>
       <range start='{{ he_ipv6_subnet_prefix + '::10' }}' end='{{ he_ipv6_subnet_prefix + '::ff' }}'/>

--- a/roles/hosted_engine_setup/templates/network-config.j2
+++ b/roles/hosted_engine_setup/templates/network-config.j2
@@ -2,19 +2,19 @@
   <name>default</name>
   <uuid>{{ network_dict['uuid'] }}</uuid>
   <forward mode='nat'>
-    <nat {% if he_ipv6_subnet_prefix is defined %}ipv6='yes' {% endif %}>
+    <nat ipv6='yes'>
       <port start='1024' end='65535'/>
     </nat>
   </forward>
   <bridge name='{{ network_dict['bridge']['name'] }}' stp='{{ network_dict['bridge']['stp'] }}' delay='{{ network_dict['bridge']['delay'] }}'/>
-{% if not he_force_ip4 and he_ipv6_subnet_prefix is defined %}
+{% if not he_force_ip4 %}
   <ip family='ipv6' address='{{ he_ipv6_subnet_prefix + '::1' }}' prefix='64'>
     <dhcp>
       <range start='{{ he_ipv6_subnet_prefix + '::10' }}' end='{{ he_ipv6_subnet_prefix + '::ff' }}'/>
     </dhcp>
   </ip>
 {% endif %}
-{% if not he_force_ip6 and he_ipv4_subnet_prefix is defined %}
+{% if not he_force_ip6 %}
   <ip address='{{ he_ipv4_subnet_prefix + '.1' }}' netmask='255.255.255.0'>
     <dhcp>
       <range start='{{ he_ipv4_subnet_prefix + '.2' }}' end='{{ he_ipv4_subnet_prefix + '.254' }}'/>


### PR DESCRIPTION
We need to replace all community modules because ansible-core 2.11 does not include any community modules.

New filter:
This patch adds `get_bridge_xml_to_dict` which converts stdout from `virsh net-dumpxml default` to the dictionary which has all bridge information. Later it is passed to the new template and used to configure the network bridge.

New template:
`network-config.j2` contains the jinja template from which the XML network configuration will be created.
Now users can specify both `he_ipv6_subnet_prefix` and `he_ipv4_subnet_prefix` and will support both modes before users could specify only one mode.
