### PR TITLE
ovirt_host: fix failed_state_after_reinstall condition

### DIFF
--- a/changelogs/fragments/371-ovirt_host-fix-failed_state_after_reinstall-condition.yml
+++ b/changelogs/fragments/371-ovirt_host-fix-failed_state_after_reinstall-condition.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_host - Fix failed_state_after_reinstall condition (https://github.com/oVirt/ovirt-ansible-collection/pull/371).

--- a/plugins/modules/ovirt_host.py
+++ b/plugins/modules/ovirt_host.py
@@ -542,7 +542,7 @@ def main():
                 activate=module.params['activate'],
                 reboot=module.params.get('reboot_after_installation'),
                 result_state=(hoststate.MAINTENANCE if module.params['activate'] is False else hoststate.UP) if host is None else None,
-                fail_condition=hosts_module.failed_state_after_reinstall if host is None else lambda h: False,
+                fail_condition=hosts_module.failed_state_after_reinstall if host is not None else lambda h: False,
             )
             if module.params['activate'] and host is not None:
                 ret = hosts_module.action(


### PR DESCRIPTION
failed_state_after_reinstall uses the host, so if the host was missing it automatically failed