### PR TITLE
engine_setup: skip pkg install in offline mode

### DIFF
--- a/changelogs/fragments/381-engine_setup-honor-ovirt_engine_setup_offline.yaml
+++ b/changelogs/fragments/381-engine_setup-honor-ovirt_engine_setup_offline.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - engine_setup - Honor ovirt_engine_setup_offline variable (https://github.com/oVirt/ovirt-ansible-collection/pull/381).

--- a/roles/engine_setup/tasks/main.yml
+++ b/roles/engine_setup/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Install required packages for oVirt Engine deployment
   include_tasks: install_packages.yml
-  when: not ovirt_engine_setup_perform_upgrade
+  when: not ovirt_engine_setup_perform_upgrade|bool and not ovirt_engine_setup_offline|bool
 
 - name: Run engine setup
   include_tasks: engine_setup.yml


### PR DESCRIPTION
Honor ovirt_engine_setup_offline and
don't try installing any engine packages if in
offline mode.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>