### PR TITLE
Backport: ovirt_remove_stale_lun: Retry "multipath -f" while removing the LUNs

### DIFF
--- a/changelogs/fragments/352-ovirt_remove_stale_lun-Retry-Multipath-f-while-removing-the-luns.yml
+++ b/changelogs/fragments/352-ovirt_remove_stale_lun-Retry-Multipath-f-while-removing-the-luns.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ovirt_remove_stale_lun - Retry "multipath -f" while removing the LUNs (https://github.com/oVirt/ovirt-ansible-collection/pull/382).

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -10,12 +10,15 @@
     loop_var: host_item
 
 - name: Remove from multipath device.
-  ansible.builtin.shell: "for dev in {{ lun_wwid }}; do multipath -f $dev; done"
+  ansible.builtin.shell: "for dev in {{ lun_wwid }}; do multipath -f $dev || exit 1; done"
   delegate_to: "{{ host_item.address }}"
   connection: ssh
   check_mode: "no"
   with_items:
     - "{{ host_info.ovirt_hosts }}"
+  register: flush_results
+  retries: 6
+  until: flush_results.rc == 0
   loop_control:
     loop_var: host_item
 


### PR DESCRIPTION
There are possiblities that the vdsm might be holding the LUN
temporarily while we run "multipath -f". In these cases, the flushing
fails with error "map in use". Retry multipath -f (6 * 5 seconds) to
workaround this race condition.