### PR TITLE
ovirt_remove_stale_lun: Use add_host instead of delegate_to

### DIFF
--- a/changelogs/fragments/390-ovirt_remove_stale_lun-Use-add_host-instead-of-delegate_to.yml
+++ b/changelogs/fragments/390-ovirt_remove_stale_lun-Use-add_host-instead-of-delegate_to.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ovirt_remove_stale_lun - Use add_host instead of delegate_to (https://github.com/oVirt/ovirt-ansible-collection/pull/390).

--- a/roles/remove_stale_lun/examples/remove_stale_lun.yml
+++ b/roles/remove_stale_lun/examples/remove_stale_lun.yml
@@ -1,5 +1,5 @@
 ---
-- name: oVirt remove stale LUN
+- name: Discover hosts in DC and add to Ansible runtime inventory
   hosts: localhost
   connection: local
   gather_facts: false
@@ -9,17 +9,26 @@
     - passwords.yml
 
   vars:
+    engine_fqdn: ovirt.example.com
+    engine_user: admin@internal
+    data_center: default
+  roles:
+    - role: remove_stale_lun
+      fetch_hosts: true
+  collections:
+    - @NAMESPACE@.@NAME@
+
+- name: Remove LUNs from the discovered hosts in DC
+  hosts: dc_hosts
+
+  vars:
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
     ansible_user: root
     ansible_ssh_private_key_file: /etc/pki/ovirt-engine/keys/engine_id_rsa
-    
-    engine_fqdn: ovirt.example.com
-    engine_user: admin@internal
-
-    data_center: default
     lun_wwid: 36001405a77a1ee25cbf4439b7ddd2062 36001405ddefe8392bb8443e89bde4b40
 
   roles:
-    - remove_stale_lun
+    - role: remove_stale_lun
+      fetch_hosts: false 
   collections:
     - @NAMESPACE@.@NAME@

--- a/roles/remove_stale_lun/tasks/fetch_hosts.yml
+++ b/roles/remove_stale_lun/tasks/fetch_hosts.yml
@@ -1,0 +1,45 @@
+---
+## https://github.com/ansible/ansible/issues/22397
+## Ansible 2.3 generates a WARNING when using {{ }} in defaults variables of role
+## this workarounds it until Ansible resolves the issue:
+- name: Initialize variables
+  set_fact:
+    data_center: "{{ data_center | mandatory }}"
+
+- block:
+    - name: Login to oVirt
+      ovirt_auth:
+        url: "{{ engine_url | default(lookup('env','OVIRT_URL')) | default(omit) }}"
+        username: "{{ engine_user | default(lookup('env','OVIRT_USERNAME')) | default(omit) }}"
+        hostname: "{{ engine_fqdn | default(lookup('env','OVIRT_HOSTNAME')) | default(omit) }}"
+        password: "{{ engine_password | default(lookup('env','OVIRT_PASSWORD')) | default(omit) }}"
+        ca_file: "{{ engine_cafile | default(lookup('env','OVIRT_CAFILE')) | default(omit) }}"
+        token: "{{ engine_token | default(lookup('env','OVIRT_TOKEN')) | default(omit) }}"
+        insecure: "{{ engine_insecure | default(true) }}"
+      when: ovirt_auth is undefined or not ovirt_auth
+      register: login_result
+      tags:
+        - always
+
+    - name: Get datacenter hosts
+      ovirt_host_info:
+        auth: "{{ ovirt_auth }}"
+        pattern: "datacenter={{ data_center }}"
+      register: host_info
+
+    - name: Add hosts
+      ansible.builtin.add_host:
+        hostname: "{{ item.address }}"
+        groups: dc_hosts
+      with_items:
+        - "{{ host_info.ovirt_hosts }}" 
+
+  always:
+    - name: Logout from oVirt
+      ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"
+      when:
+        - login_result.skipped is defined and not login_result.skipped
+      tags:
+        - always

--- a/roles/remove_stale_lun/tasks/main.yml
+++ b/roles/remove_stale_lun/tasks/main.yml
@@ -1,41 +1,5 @@
----
-## https://github.com/ansible/ansible/issues/22397
-## Ansible 2.3 generates a WARNING when using {{ }} in defaults variables of role
-## this workarounds it until Ansible resolves the issue:
-- name: Initialize variables
-  set_fact:
-    data_center: "{{ data_center | mandatory }}"
-    lun_wwid: "{{ lun_wwid | mandatory }}"
+- include_tasks: fetch_hosts.yml
+  when: fetch_hosts
 
-- block:
-    - name: Login to oVirt
-      ovirt_auth:
-        url: "{{ engine_url | default(lookup('env','OVIRT_URL')) | default(omit) }}"
-        username: "{{ engine_user | default(lookup('env','OVIRT_USERNAME')) | default(omit) }}"
-        hostname: "{{ engine_fqdn | default(lookup('env','OVIRT_HOSTNAME')) | default(omit) }}"
-        password: "{{ engine_password | default(lookup('env','OVIRT_PASSWORD')) | default(omit) }}"
-        ca_file: "{{ engine_cafile | default(lookup('env','OVIRT_CAFILE')) | default(omit) }}"
-        token: "{{ engine_token | default(lookup('env','OVIRT_TOKEN')) | default(omit) }}"
-        insecure: "{{ engine_insecure | default(true) }}"
-      when: ovirt_auth is undefined or not ovirt_auth
-      register: login_result
-      tags:
-        - always
-
-    - name: Get datacenter hosts
-      ovirt_host_info:
-        auth: "{{ ovirt_auth }}"
-        pattern: "datacenter={{ data_center }}"
-      register: host_info
-
-    - include_tasks: remove_mpath_device.yml
-
-  always:
-    - name: Logout from oVirt
-      ovirt_auth:
-        state: absent
-        ovirt_auth: "{{ ovirt_auth }}"
-      when:
-        - login_result.skipped is defined and not login_result.skipped
-      tags:
-        - always
+- include_tasks: remove_mpath_device.yml
+  when: not fetch_hosts

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -1,33 +1,21 @@
+- name: Initialize variables
+  set_fact:
+    lun_wwid: "{{ lun_wwid | mandatory }}"
+
 - name: Get underlying disks (paths) for a multipath device(s) and turn them into a list.
   ansible.builtin.shell: 'for dev in {{ lun_wwid }}; do dmsetup deps -o devname $dev | cut -f 2 |cut -c 3- |tr -d "()"|tr "\r\n" " "; done'
   register: disks
-  delegate_to: "{{ host_item.address }}"
-  connection: ssh
   check_mode: "no"
-  with_items:
-    - "{{ host_info.ovirt_hosts }}"
-  loop_control:
-    loop_var: host_item
 
 - name: Remove from multipath device.
   ansible.builtin.shell: "for dev in {{ lun_wwid }}; do multipath -f $dev || exit 1; done"
-  delegate_to: "{{ host_item.address }}"
-  connection: ssh
-  check_mode: "no"
-  with_items:
-    - "{{ host_info.ovirt_hosts }}"
   register: flush_results
   retries: 6
+  check_mode: "no"
   until: flush_results.rc == 0
-  loop_control:
-    loop_var: host_item
 
 - name: Remove each path from the SCSI subsystem.
-  ansible.builtin.shell: "for dev in {{ result.stdout }}; do echo 1 > /sys/block/$dev/device/delete; done"
-  delegate_to: "{{ result.host_item.address }}"
-  connection: ssh
+  ansible.builtin.shell: "for dev in {{ item.stdout }}; do echo 1 > /sys/block/$dev/device/delete; done"
   check_mode: "no"
   with_items:
-    - "{{ disks.results }}"
-  loop_control:
-    loop_var: result
+    - "{{ disks }}"


### PR DESCRIPTION
As of now, we are using delegate_to using with_items to run the tasks in multiple hosts. This has got several problems:

- Ansible considers tasks for all the hosts as single task since we are iterating over host_info using with_items to run it on multiple hosts. So if any of the tasks fails in any of the hosts, it stops the execution of the subsequent tasks on all other hosts. For example, if multipath -f fails on any hosts, it won't run the task for removing the SCSI device even for the hosts where it was able to remove the device from multipath successfully.

- Each task is executed serially on the discovered hosts in DC because with_items unpacks serially.

- It's very difficult to understand which host it got failed, and "PLAY RECAP" is not useful.

Using add_host automatically solves the above problems.