### PR TITLE
Add follow link url to api model links_summary

### DIFF
--- a/changelogs/fragments/396-info-modules-add-follow-link-url.yml
+++ b/changelogs/fragments/396-info-modules-add-follow-link-url.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - info modules - Add follow link url to api model links_summary

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -28,14 +28,6 @@ options:
             - This parameter is deprecated and replaced by C(follows).
         type: list
         elements: str
-    follow:
-      description:
-        - List of linked entities, which should be fetched along with the main entity.
-        - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-      type: list
-      version_added: 1.5.0
-      elements: str
-      aliases: ['follows']
     auth:
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"

--- a/plugins/doc_fragments/ovirt_info.py
+++ b/plugins/doc_fragments/ovirt_info.py
@@ -18,14 +18,14 @@ options:
             - It will fetch only IDs of nested entity. It doesn't fetch multiple levels of nested attributes.
               Only the attributes of the current entity. User can configure to fetch other
               attributes of the nested entities by specifying C(nested_attributes).
-            - This parameter is deprecated and replaced by C(follows).
+            - This parameter is deprecated and replaced by C(follow).
         type: bool
         default: false
     nested_attributes:
         description:
             - Specifies list of the attributes which should be fetched from the API.
             - This parameter apply only when C(fetch_nested) is I(true).
-            - This parameter is deprecated and replaced by C(follows).
+            - This parameter is deprecated and replaced by C(follow).
         type: list
         elements: str
     auth:

--- a/plugins/modules/ovirt_affinity_label_info.py
+++ b/plugins/modules/ovirt_affinity_label_info.py
@@ -53,7 +53,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/affinity_label/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/affinity_label/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_affinity_label_info.py
+++ b/plugins/modules/ovirt_affinity_label_info.py
@@ -49,6 +49,15 @@ options:
         description:
             - "Name of the host, which affinity labels should be listed."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/affinity_label/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_api_info.py
+++ b/plugins/modules/ovirt_api_info.py
@@ -17,6 +17,15 @@ description:
     - "Retrieve information about the oVirt/RHV API."
     - This module was called C(ovirt_api_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(@NAMESPACE@.@NAME@.ovirt_api_info) module no longer returns C(ansible_facts)!
+    follow:
+      description:
+        - List of linked entities, which should be fetched along with the main entity.
+        - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+        - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/api/links_summary"
+      type: list
+      version_added: 1.5.0
+      elements: str
+      aliases: ['follows']
 notes:
     - "This module returns a variable C(ovirt_api),
        which contains a information about oVirt/RHV API. You need to register the result with

--- a/plugins/modules/ovirt_api_info.py
+++ b/plugins/modules/ovirt_api_info.py
@@ -17,6 +17,7 @@ description:
     - "Retrieve information about the oVirt/RHV API."
     - This module was called C(ovirt_api_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(@NAMESPACE@.@NAME@.ovirt_api_info) module no longer returns C(ansible_facts)!
+options:
     follow:
       description:
         - List of linked entities, which should be fetched along with the main entity.

--- a/plugins/modules/ovirt_cluster_info.py
+++ b/plugins/modules/ovirt_cluster_info.py
@@ -45,6 +45,15 @@ options:
             - "For example to search cluster X from datacenter Y use following pattern:
                name=X and datacenter=Y"
         type: str
+    follow:
+      description:
+        - List of linked entities, which should be fetched along with the main entity.
+        - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+        - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/cluster/links_summary
+      type: list
+      version_added: 1.5.0
+      elements: str
+      aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_cluster_info.py
+++ b/plugins/modules/ovirt_cluster_info.py
@@ -49,7 +49,7 @@ options:
       description:
         - List of linked entities, which should be fetched along with the main entity.
         - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-        - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/cluster/links_summary
+        - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/cluster/links_summary"
       type: list
       version_added: 1.5.0
       elements: str

--- a/plugins/modules/ovirt_datacenter_info.py
+++ b/plugins/modules/ovirt_datacenter_info.py
@@ -29,6 +29,15 @@ options:
             - "Search term which is accepted by oVirt/RHV search backend."
             - "For example to search datacenter I(X) use following pattern: I(name=X)"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/data_center/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_datacenter_info.py
+++ b/plugins/modules/ovirt_datacenter_info.py
@@ -33,7 +33,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/data_center/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/data_center/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_disk_info.py
+++ b/plugins/modules/ovirt_disk_info.py
@@ -43,6 +43,15 @@ options:
             - "For example to search Disk X from storage Y use following pattern:
                name=X and storage.name=Y"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/disk/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_disk_info.py
+++ b/plugins/modules/ovirt_disk_info.py
@@ -47,7 +47,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/disk/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/disk/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_event_info.py
+++ b/plugins/modules/ovirt_event_info.py
@@ -60,6 +60,15 @@ options:
         required: false
         default: true
         type: bool
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/event/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_event_info.py
+++ b/plugins/modules/ovirt_event_info.py
@@ -64,7 +64,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/event/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/event/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_external_provider_info.py
+++ b/plugins/modules/ovirt_external_provider_info.py
@@ -48,6 +48,22 @@ options:
         description:
             - "Name of the external provider, can be used as glob expression."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - For type C(foreman), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/external_host_provider/links_summary
+            - For type C(os_image), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_image_provider/links_summary
+            - For type C(os_volume), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_volume_provider/links_summary
+            - For type C(os_network), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_network_provider/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 
@@ -71,11 +87,11 @@ ovirt_external_providers:
         - "For type C(foreman), attributes appearing in the dictionary can be found on your oVirt/RHV instance
            at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/external_host_provider."
         - "For type C(os_image), attributes appearing in the dictionary can be found on your oVirt/RHV instance
-           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_image_provider."
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_image_provider."
         - "For type C(os_volume), attributes appearing in the dictionary can be found on your oVirt/RHV instance
-           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_volume_provider."
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_volume_provider."
         - "For type C(os_network), attributes appearing in the dictionary can be found on your oVirt/RHV instance
-           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_network_provider."
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_network_provider."
     returned: On success
     type: list
 '''

--- a/plugins/modules/ovirt_external_provider_info.py
+++ b/plugins/modules/ovirt_external_provider_info.py
@@ -52,14 +52,14 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - For type C(foreman), all follow parameters can be found at following url:
-              https://ovirt.github.io/ovirt-engine-api-model/master/#types/external_host_provider/links_summary
-            - For type C(os_image), all follow parameters can be found at following url:
-              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_image_provider/links_summary
-            - For type C(os_volume), all follow parameters can be found at following url:
-              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_volume_provider/links_summary
-            - For type C(os_network), all follow parameters can be found at following url:
-              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_network_provider/links_summary
+            - "For type C(foreman), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/external_host_provider/links_summary"
+            - "For type C(os_image), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_image_provider/links_summary"
+            - "For type C(os_volume), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_volume_provider/links_summary"
+            - "For type C(os_network), all follow parameters can be found at following url:
+              https://ovirt.github.io/ovirt-engine-api-model/master/#types/open_stack_network_provider/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_group_info.py
+++ b/plugins/modules/ovirt_group_info.py
@@ -46,7 +46,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/group/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/group/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_group_info.py
+++ b/plugins/modules/ovirt_group_info.py
@@ -42,6 +42,15 @@ options:
             - "Search term which is accepted by oVirt/RHV search backend."
             - "For example to search group X use following pattern: name=X"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/group/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_host_info.py
+++ b/plugins/modules/ovirt_host_info.py
@@ -44,7 +44,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_host_info.py
+++ b/plugins/modules/ovirt_host_info.py
@@ -40,7 +40,15 @@ options:
         description:
             - "Filter the hosts based on the cluster version."
         type: str
-
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -57,6 +57,15 @@ options:
                 description:
                   - "LUN id."
         type: dict
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host_storage/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -61,7 +61,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host_storage/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/host_storage/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_network_info.py
+++ b/plugins/modules/ovirt_network_info.py
@@ -44,6 +44,15 @@ options:
             - "Search term which is accepted by oVirt/RHV search backend."
             - "For example to search network starting with string vlan1 use: name=vlan1*"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/network/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_network_info.py
+++ b/plugins/modules/ovirt_network_info.py
@@ -48,7 +48,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/network/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/network/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_nic_info.py
+++ b/plugins/modules/ovirt_nic_info.py
@@ -58,7 +58,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/nic/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/nic/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_nic_info.py
+++ b/plugins/modules/ovirt_nic_info.py
@@ -54,6 +54,15 @@ options:
         description:
             - "Name of the NIC, can be used as glob expression."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/nic/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_permission_info.py
+++ b/plugins/modules/ovirt_permission_info.py
@@ -58,6 +58,15 @@ options:
             - "Namespace of the authorization provider, where user/group resides."
         required: false
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/permission/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_permission_info.py
+++ b/plugins/modules/ovirt_permission_info.py
@@ -62,7 +62,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/permission/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/permission/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_quota_info.py
+++ b/plugins/modules/ovirt_quota_info.py
@@ -46,6 +46,15 @@ options:
         description:
             - "Name of the quota, can be used as glob expression."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/quota/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_quota_info.py
+++ b/plugins/modules/ovirt_quota_info.py
@@ -50,7 +50,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/quota/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/quota/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -49,7 +49,8 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/scheduling_policy/links_summary"
+            - "All follow parameters can be found at following url:
+               https://ovirt.github.io/ovirt-engine-api-model/master/#types/scheduling_policy/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -49,7 +49,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/scheduling_policy/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/scheduling_policy/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -45,6 +45,15 @@ options:
         description:
             - "Name of the scheduling policy, can be used as glob expression."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/scheduling_policy/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_snapshot_info.py
+++ b/plugins/modules/ovirt_snapshot_info.py
@@ -37,6 +37,15 @@ options:
         description:
             - "Id of the snapshot we want to retrieve information about."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/snapshot/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_snapshot_info.py
+++ b/plugins/modules/ovirt_snapshot_info.py
@@ -41,7 +41,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/snapshot/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/snapshot/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_storage_domain_info.py
+++ b/plugins/modules/ovirt_storage_domain_info.py
@@ -45,6 +45,15 @@ options:
             - "For example to search storage domain X from datacenter Y use following pattern:
                name=X and datacenter=Y"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/storage_domain/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_storage_domain_info.py
+++ b/plugins/modules/ovirt_storage_domain_info.py
@@ -49,7 +49,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/storage_domain/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/storage_domain/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_storage_template_info.py
+++ b/plugins/modules/ovirt_storage_template_info.py
@@ -52,6 +52,15 @@ options:
             - "The storage domain name where the templates should be listed."
         type: str
         required: true
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_storage_template_info.py
+++ b/plugins/modules/ovirt_storage_template_info.py
@@ -56,7 +56,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_storage_vm_info.py
+++ b/plugins/modules/ovirt_storage_vm_info.py
@@ -56,7 +56,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_storage_vm_info.py
+++ b/plugins/modules/ovirt_storage_vm_info.py
@@ -52,6 +52,15 @@ options:
             - "The storage domain name where the virtual machines should be listed."
         type: str
         required: True
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -43,6 +43,15 @@ options:
         description:
             - "The version of the option."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/system_option/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -47,7 +47,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/system_option/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/system_option/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_tag_info.py
+++ b/plugins/modules/ovirt_tag_info.py
@@ -51,6 +51,15 @@ options:
         description:
             - "Name of the host, which tags should be listed."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/tag/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_tag_info.py
+++ b/plugins/modules/ovirt_tag_info.py
@@ -55,7 +55,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/tag/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/tag/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_template_info.py
+++ b/plugins/modules/ovirt_template_info.py
@@ -45,6 +45,15 @@ options:
             - "For example to search template X from datacenter Y use following pattern:
                name=X and datacenter=Y"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_template_info.py
+++ b/plugins/modules/ovirt_template_info.py
@@ -49,7 +49,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/template/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_user_info.py
+++ b/plugins/modules/ovirt_user_info.py
@@ -46,7 +46,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/user/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/user/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_user_info.py
+++ b/plugins/modules/ovirt_user_info.py
@@ -42,6 +42,15 @@ options:
             - "Search term which is accepted by oVirt/RHV search backend."
             - "For example to search user X use following pattern: name=X"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/user/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -72,6 +72,15 @@ options:
       type: bool
       default: false
       version_added: 1.2.0
+    follow:
+      description:
+        - List of linked entities, which should be fetched along with the main entity.
+        - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+        - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary
+      type: list
+      version_added: 1.5.0
+      elements: str
+      aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -76,7 +76,7 @@ options:
       description:
         - List of linked entities, which should be fetched along with the main entity.
         - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-        - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary
+        - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary"
       type: list
       version_added: 1.5.0
       elements: str

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -46,6 +46,15 @@ options:
       description:
         - "Name of the operating system which should be returned."
       type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -50,7 +50,8 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info/links_summary"
+            - "All follow parameters can be found at following url:
+               https://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -50,7 +50,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/operating_system_info/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_vmpool_info.py
+++ b/plugins/modules/ovirt_vmpool_info.py
@@ -44,6 +44,15 @@ options:
             - "Search term which is accepted by oVirt/RHV search backend."
             - "For example to search vmpool X: name=X"
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm_pool/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 

--- a/plugins/modules/ovirt_vmpool_info.py
+++ b/plugins/modules/ovirt_vmpool_info.py
@@ -48,7 +48,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm_pool/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm_pool/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_vnic_profile_info.py
+++ b/plugins/modules/ovirt_vnic_profile_info.py
@@ -47,7 +47,7 @@ options:
         description:
             - List of linked entities, which should be fetched along with the main entity.
             - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
-            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vnic_profile/links_summary
+            - "All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vnic_profile/links_summary"
         type: list
         version_added: 1.5.0
         elements: str

--- a/plugins/modules/ovirt_vnic_profile_info.py
+++ b/plugins/modules/ovirt_vnic_profile_info.py
@@ -43,6 +43,15 @@ options:
         description:
             - "Name of vnic profile."
         type: str
+    follow:
+        description:
+            - List of linked entities, which should be fetched along with the main entity.
+            - This parameter replaces usage of C(fetch_nested) and C(nested_attributes).
+            - All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vnic_profile/links_summary
+        type: list
+        version_added: 1.5.0
+        elements: str
+        aliases: ['follows']
 extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt_info
 '''
 


### PR DESCRIPTION
Add to each info module proper api-model links summary address.
Example for ovirt_vm_info:
All follow parameters can be found at following url: https://ovirt.github.io/ovirt-engine-api-model/master/#types/vm/links_summary