### PR TITLE
roles: hosted_engine_setup: check if abrt config files exists on HE deploy

### DIFF
--- a/changelogs/fragments/397-he_engine_abrt_configuration.yaml
+++ b/changelogs/fragments/397-he_engine_abrt_configuration.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - configured abrt initial files only when needed (https://github.com/oVirt/ovirt-ansible-collection/pull/397).

--- a/roles/hosted_engine_setup/tasks/initial_clean.yml
+++ b/roles/hosted_engine_setup/tasks/initial_clean.yml
@@ -29,6 +29,10 @@
     args:
       warn: false
     environment: "{{ he_cmd_lang }}"
+  - name: Verify abrt-action-save-package-data file
+    stat:
+      path: /etc/abrt/abrt-action-save-package-data.conf
+    register: abrt_exists
   - name: Restore initial abrt config files
     copy:
       remote_src: true
@@ -52,10 +56,12 @@
         src: /usr/share/abrt/conf.d/plugins/vmcore.conf,
         dest: /etc/abrt/plugins/vmcore.conf
       }
+    when: abrt_exists.stat.exists
   - name: Restart abrtd service
     service:
       name: abrtd
       state: restarted
+    when: abrt_exists.stat.exists
   - name: Drop libvirt sasl2 configuration by vdsm
     command: >-
       sed -i '/## start vdsm-4.[0-9]\+.[0-9]\+ configuration/,/## end vdsm configuration/d' /etc/sasl2/libvirt.conf


### PR DESCRIPTION
Our abrt configuration is not being used on latest versions since we started
using 'systemd-coredump'.
because of that we should Restore initial abrt config files only when
they exist (on older versions).