### PR TITLE
Fetch the whole git history for the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,15 +14,17 @@ jobs:
     container:
       image: quay.io/centos/centos:stream8
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Install packages
         run: yum install -y rpm-build yum-utils git epel-release
       - name: Install ansible packages
         run: yum install -y ansible ansible-test python3-pycodestyle python3-pylint python3-voluptuous yamllint glibc-langpack-en
       - name: Update all packages
         run: yum update -y
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Run build.sh
         run: ./automation/build.sh


### PR DESCRIPTION
Fetch the whole git history for the build so build job can verify if
changelog is required.

Fixes: #405 
Signed-off-by: Martin Perina <mperina@redhat.com>