### PR TITLE
roles: hosted_engine_setup: Adjust files permissions

### DIFF
--- a/changelogs/fragments/409-hosted_engine_setup-Adjust-files-permissions.yml
+++ b/changelogs/fragments/409-hosted_engine_setup-Adjust-files-permissions.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Adjust files permissions (https://github.com/oVirt/ovirt-ansible-collection/pull/409).

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -23,13 +23,6 @@
       - name: Set local vm dir path
         set_fact:
           he_local_vm_dir: "{{ otopi_localvm_dir.path }}"
-      - name: Fix local VM directory permission
-        file:
-          state: directory
-          path: "{{ he_local_vm_dir }}"
-          owner: vdsm
-          group: kvm
-          mode: 0775
       - include_tasks: ../install_appliance.yml
         when: he_appliance_ova is none or he_appliance_ova|length == 0
       - name: Register appliance PATH
@@ -82,6 +75,7 @@
         template:
           src: "{{ item.src }}"
           dest: "{{ item.dest }}"
+          mode: 0640
         with_items:
           - {src: templates/user-data.j2, dest: "{{ he_local_vm_dir }}/user-data"}
           - {src: templates/meta-data.j2, dest: "{{ he_local_vm_dir }}/meta-data"}
@@ -93,6 +87,14 @@
           {{ he_local_vm_dir }}/network-config
         environment: "{{ he_cmd_lang }}"
         changed_when: true
+      - name: Fix local VM directory permission
+        file:
+          state: directory
+          path: "{{ he_local_vm_dir }}"
+          owner: vdsm
+          group: qemu
+          recurse: yes
+          mode: u=rwX,g=rwX,o=
       - name: Create local VM
         command: >-
           virt-install -n {{ he_vm_name }}Local --os-variant rhel8.0 --virt-type kvm --memory {{ he_mem_size_MB }}

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -155,8 +155,6 @@
       of="{{ he_conf_disk_path }}"
     environment: "{{ he_cmd_lang }}"
     become: true
-    become_user: vdsm
-    become_method: sudo
     changed_when: true
     args:
       warn: false


### PR DESCRIPTION
Adjusting files permissions for supporting umask 077.

For security purposes we decided to use 770/660 permissions for the localvm directory, this directory contains the appliance image, and for creating the engine VM we must have its user/group configured for `qemu`, otherwise `qemu` user won't have search permissions for the appliance image (see also https://libvirt.org/drvqemu.html#posix-users-groups).
Therefore we have decided to use `qemu` group instead of `kvm`.

Bug-Url: https://bugzilla.redhat.com/2020620
Signed-off-by: Asaf Rachmani <arachman@redhat.com>