### PR TITLE
Fixes rich dependency issue in ansible-lint

### DIFF
--- a/automation/build.sh
+++ b/automation/build.sh
@@ -68,7 +68,7 @@ mkdir -p $COLLECTION_DIR
 cp -r $OVIRT_BUILD/* $COLLECTION_DIR
 cd $COLLECTION_DIR
 
-pip3 install rstcheck antsibull-changelog "ansible-lint<5.0.0"
+pip3 install rstcheck antsibull-changelog "rich<11.0.0" "ansible-lint<5.0.0"
 
 # The sanity import test failed with error. (https://github.com/ansible/ansible/issues/76473)
 ansible-test sanity --skip-test import


### PR DESCRIPTION
Fixes ImportError exceptioin when using rich >= 11.0.0 in ansible-lint:
https://github.com/ansible-community/ansible-lint/issues/1795

Signed-off-by: Martin Perina <mperina@redhat.com>
