### PR TITLE
roles: cluster_upgrade: Add progress tracking/reporting

### DIFF
--- a/changelogs/fragments/415-cluster_upgrade-progress.yml
+++ b/changelogs/fragments/415-cluster_upgrade-progress.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cluster_upgrade - Add progress tracking via event logs to the role (https://github.com/oVirt/ovirt-ansible-collection/pull/415)

--- a/roles/cluster_upgrade/README.md
+++ b/roles/cluster_upgrade/README.md
@@ -9,7 +9,6 @@ Role Variables
 | Name                    | Default value         |                                                     |
 |-------------------------|-----------------------|-----------------------------------------------------|
 | cluster_name            | Default               | Name of the cluster to be upgraded.                 |
-| stopped_vms             | UNDEF                 | List of virtual machines to stop before upgrading.      |
 | stop_non_migratable_vms <br/> <i>alias: stop_pinned_to_host_vms</i>  | false                 | Specify whether to stop virtual machines pinned to the host being upgraded. If true, the pinned non-migratable virtual machines will be stopped and host will be upgraded, otherwise the host will be skipped. |
 | upgrade_timeout         | 3600                  | Timeout in seconds to wait for host to be upgraded. |
 | host_statuses           | [UP]                  | List of host statuses. If a host is in any of the specified statuses then it will be upgraded. |
@@ -39,10 +38,6 @@ Example Playbook
     engine_cafile: /etc/pki/ovirt-engine/ca.pem
 
     cluster_name: production
-    stopped_vms:
-      - openshift-master-0
-      - openshift-node-0
-      - openshift-node-image
 
   roles:
     - cluster_upgrade

--- a/roles/cluster_upgrade/README.md
+++ b/roles/cluster_upgrade/README.md
@@ -9,6 +9,7 @@ Role Variables
 | Name                    | Default value         |                                                     |
 |-------------------------|-----------------------|-----------------------------------------------------|
 | cluster_name            | Default               | Name of the cluster to be upgraded.                 |
+| stopped_vms             | UNDEF                 | List of virtual machines to stop before upgrading.      |
 | stop_non_migratable_vms <br/> <i>alias: stop_pinned_to_host_vms</i>  | false                 | Specify whether to stop virtual machines pinned to the host being upgraded. If true, the pinned non-migratable virtual machines will be stopped and host will be upgraded, otherwise the host will be skipped. |
 | upgrade_timeout         | 3600                  | Timeout in seconds to wait for host to be upgraded. |
 | host_statuses           | [UP]                  | List of host statuses. If a host is in any of the specified statuses then it will be upgraded. |
@@ -38,6 +39,10 @@ Example Playbook
     engine_cafile: /etc/pki/ovirt-engine/ca.pem
 
     cluster_name: production
+    stopped_vms:
+      - openshift-master-0
+      - openshift-node-0
+      - openshift-node-image
 
   roles:
     - cluster_upgrade

--- a/roles/cluster_upgrade/tasks/cluster_policy.yml
+++ b/roles/cluster_upgrade/tasks/cluster_policy.yml
@@ -1,3 +1,4 @@
+---
 - name: Get name of the original scheduling policy
   ovirt_scheduling_policy_info:
     auth: "{{ ovirt_auth }}"

--- a/roles/cluster_upgrade/tasks/log_progress.yml
+++ b/roles/cluster_upgrade/tasks/log_progress.yml
@@ -1,0 +1,23 @@
+---
+# vars:
+#  progress: % complete
+#  cluster_name: (if available) what cluster is being worked on
+#  host_name: (if avaiable) what host in the cluster is being worked on
+#  description: what part of the process is actually done
+
+- block:
+  - name: Log progress as an event
+    vars:
+      message:
+        - "Cluster upgrade progress: {{ progress }}%"
+        - "{{ ', Cluster: ' + cluster_name if (cluster_name is defined and cluster_name) else '' }}"
+        - "{{ ', Host: ' + host_name if (host_name is defined and host_name) else '' }}"
+        - " [{{ description }}]"
+    ovirt_event:
+      auth: "{{ ovirt_auth }}"
+      state: present
+      severity: normal
+      custom_id: "{{ 2147483647 | random | int }}"
+      origin: "cluster_upgrade"
+      description: "{{ message | join('') }}"
+      cluster: "{{ cluster_id | default(omit) }}"

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -231,15 +231,6 @@
             progress: 95
             description: "host upgrades are done (successful or not), restarting non-migratable VMs"
 
-        # TODO: These VMs aren't explicity stopped anywhere...should they be?
-        - name: Start again stopped VMs
-          ovirt_vm:
-            auth: "{{ ovirt_auth }}"
-            name: "{{ item }}"
-            state: running
-          ignore_errors: "yes"
-          loop: "{{ stopped_vms | default([]) | flatten(levels=1) }}"
-
         - name: Start again pin to host VMs
           ovirt_vm:
             auth: "{{ ovirt_auth }}"

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -24,122 +24,177 @@
       tags:
         - always
 
+    - name: progress 0% - need to do info lookups
+      include_tasks: log_progress.yml
+      vars:
+        progress: 0
+        description: "gathering cluster info"
+
     - name: Get API info
       ovirt_api_info:
         auth: "{{ ovirt_auth }}"
-      register: api_info
       check_mode: "no"
+      register: api_info
 
     - name: Get cluster info
       ovirt_cluster_info:
         auth: "{{ ovirt_auth }}"
         pattern: "name={{ cluster_name }}"
-        fetch_nested: True
-        nested_attributes: name
+        follow: gluster_volumes
       check_mode: "no"
       register: cluster_info
 
-    - name: Set cluster upgrade status in progress
-      no_log: true
+    - name: Remember the api version and cluster id
+      set_fact:
+        api_gt43: "{{ api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 3 }}"
+        cluster_id: "{{ cluster_info.ovirt_clusters[0].id }}"
+
+    - name: progress 2% - cluster upgrade is starting
+      include_tasks: log_progress.yml
+      vars:
+        progress: 2
+        description: "starting upgrade"
+
+    - name: Set cluster upgrade status to running
+      no_log: false
       uri:
-        url: "{{ ovirt_auth.url }}/clusters/{{ cluster_info.ovirt_clusters[0].id }}/upgrade"
+        url: "{{ ovirt_auth.url }}/clusters/{{ cluster_id }}/upgrade"
         method: POST
         body_format: json
         validate_certs: false
         headers:
           Authorization: "Bearer {{ ovirt_auth.token }}"
+          Correlation-Id: "{{ engine_correlation_id }}"
         body:
           upgrade_action: start
+      when: api_gt43
       register: upgrade_set
-      when: api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 3
 
-    - name: Log event cluster upgrade has started
-      ovirt_event:
-        auth: "{{ ovirt_auth }}"
-        state: present
-        description: "Cluster upgrade started for {{ cluster_name }}."
-        origin: "cluster_upgrade"
-        custom_id: "{{ 2147483647 | random | int }}"
-        severity: normal
-        cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
+    - name: progress 4% - all necessary info is all looked up, hosts can now be upgraded
+      include_tasks: log_progress.yml
+      vars:
+        progress: 4
+        description: "collecting hosts to upgrade"
 
     - name: Get hosts
       ovirt_host_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "cluster={{ cluster_name | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names | map('regex_replace', '^(.*)$', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\\1') | list | join(' or ') }}"
+        pattern: >-
+          cluster={{ cluster_name | mandatory }}
+          {{ check_upgrade | ternary('', 'update_available=true') }}
+          {{ host_names | map('regex_replace', '^(.*)$', 'name=\1') | list | join(' or ') }}
+          {{ host_statuses | map('regex_replace', '^(.*)$', 'status=\1') | list | join(' or ') }}
       check_mode: "no"
       register: host_info
 
     - block:
-      - name: Print - no hosts to be updated
+      - name: Print - no hosts to be upgraded
         debug:
-          msg: "No hosts to be updated"
+          msg: "No hosts to be upgraded"
 
-      - name: Log event - no hosts to be updated
+      - name: progress 100% - no host need to be upgraded!
+        include_tasks: log_progress.yml
+        vars:
+          progress: 100
+          description: "no hosts need to be upgraded!"
+
+      - name: Log event - no hosts to be upgraded
         ovirt_event:
           auth: "{{ ovirt_auth }}"
           state: present
-          description: "There are no hosts to be updated for cluster {{ cluster_name }}."
+          description: "Upgrade of cluster {{ cluster_name }} complete, there are no hosts to be upgraded."
           origin: "cluster_upgrade"
           custom_id: "{{ 2147483647 | random | int }}"
           severity: normal
-          cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
+          cluster: "{{ cluster_id }}"
+
       when: host_info.ovirt_hosts | length == 0
 
     - block:
-        - name: Log event about hosts that are marked to be updated
-          ovirt_event:
-            auth: "{{ ovirt_auth }}"
-            state: present
-            description: "Hosts {{ host_info.ovirt_hosts | map(attribute='name') | join(',') }} are marked to be updated in cluster {{ cluster_name }}."
-            origin: "cluster_upgrade"
-            custom_id: "{{ 2147483647 | random | int }}"
-            severity: normal
-            cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
+      - name: Start ovirt job session
+        ovirt_job:
+          auth: "{{ ovirt_auth }}"
+          description: "Upgrading hosts in {{ cluster_name }}"
 
-        - include_tasks: cluster_policy.yml
-          when: use_maintenance_policy
+      - name: progress 6% - log hosts that are marked to be upgraded
+        include_tasks: log_progress.yml
+        vars:
+          progress: 6
+          description: "hosts to check for pinned VMs: {{ host_info.ovirt_hosts | map(attribute='name') | join(',') }}"
 
-        - name: Get list of VMs in cluster
-          ovirt_vm_info:
-            auth: "{{ ovirt_auth }}"
-            pattern: "cluster={{ cluster_name }}"
-          check_mode: "no"
-          register: vms_in_cluster
+      - name: Change cluster scheduling_policy to cluster_maintenance
+        include_tasks: cluster_policy.yml
+        when: use_maintenance_policy
 
-        - include_tasks: pinned_vms.yml
+      - name: Get list of VMs in cluster
+        ovirt_vm_info:
+          auth: "{{ ovirt_auth }}"
+          pattern: "cluster={{ cluster_name }}"
+        check_mode: "no"
+        register: vms_in_cluster
 
-        - name: Start ovirt job session
-          ovirt_job:
-            auth: "{{ ovirt_auth }}"
-            description: "Upgrading hosts"
+      - name: Determine what hosts have running pinned vms, they will not be upgraded
+        include_tasks: pinned_vms.yml
 
-        # Update only those hosts that aren't in list of hosts were VMs are pinned
-        # or if stop_non_migratable_vms is enabled, which means we stop pinned VMs
-        - include_tasks: upgrade.yml
-          with_items:
-            - "{{ host_info.ovirt_hosts }}"
-          when: "item.id not in host_ids or stop_non_migratable_vms"
+      - name: Build the list of hosts that will be upgraded (hosts in host_info.ovirt_hosts hosts w/o pinned vms that cannot be stopped)
+        set_fact:
+          good_hosts: "{{ (good_hosts | default([])) | list + [ host ] | list }}"
+        loop: "{{ host_info.ovirt_hosts | flatten(levels=1) }}"
+        loop_control:
+          loop_var: "host"
+        when: "host.id not in host_ids or stop_non_migratable_vms"
 
-        - name: Start ovirt job session
-          ovirt_job:
-            auth: "{{ ovirt_auth }}"
-            description: "Upgrading hosts"
-            state: finished
+      - name: progress 8% - log hosts that will be upgraded
+        include_tasks: log_progress.yml
+        vars:
+          progress: 8
+          description: "hosts to be upgraded: {{ good_hosts | map(attribute='name') | join(',') }}"
 
-        - name: Log event about cluster upgrade finished successfully
-          ovirt_event:
-            auth: "{{ ovirt_auth }}"
-            state: present
-            description: "Upgrade of cluster {{ cluster_name }} finished successfully."
-            origin: "cluster_upgrade"
-            severity: normal
-            custom_id: "{{ 2147483647 | random | int }}"
-            cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
+      - name: progress 10% - host upgrades starting
+        include_tasks: log_progress.yml
+        vars:
+          progress: 10
+          description: "starting the upgrade of {{ good_hosts | length }} hosts"
+
+      # Upgrade only those hosts that aren't in list of hosts were VMs are pinned
+      # or if stop_non_migratable_vms is enabled, which means we stop pinned VMs
+      # Note: Progress goes from 10% to 95%, each host taking up an equal amount of progress
+      - name: Upgrade the hosts in the cluster
+        include_tasks: upgrade.yml
+        vars:
+          progress_start: 10
+          progress_end: 95
+        loop: "{{ good_hosts | flatten(levels=1) }}"
+        loop_control:
+          extended: yes
+          loop_var: "host"
+
+      - name: Finish ovirt job session
+        ovirt_job:
+          auth: "{{ ovirt_auth }}"
+          description: "Upgrading hosts in {{ cluster_name }}"
+          state: finished
+
+      - name: progress 95% - host upgrades completed successfully, only thing left is to start any non-migratable VMs stopped by the playbook
+        include_tasks: log_progress.yml
+        vars:
+          progress: 95
+          description: "the upgrade of {{ good_hosts | length }} hosts finished successfully"
+
+      - name: Log event - cluster upgrade finished successfully
+        ovirt_event:
+          auth: "{{ ovirt_auth }}"
+          state: present
+          description: "Upgrade of cluster {{ cluster_name }} finished successfully."
+          origin: "cluster_upgrade"
+          severity: normal
+          custom_id: "{{ 2147483647 | random | int }}"
+          cluster: "{{ cluster_id }}"
 
       when: host_info.ovirt_hosts | length > 0
+
       rescue:
-        - name: Log event about cluster upgrade failed
+        - name: Log event - cluster upgrade failed
           ovirt_event:
             auth: "{{ ovirt_auth }}"
             state: present
@@ -147,13 +202,19 @@
             origin: "cluster_upgrade"
             custom_id: "{{ 2147483647 | random | int }}"
             severity: error
-            cluster: "{{ cluster_info.ovirt_clusters[0].id }}"
+            cluster: "{{ cluster_id }}"
 
-        - name: Update job failed
+        - name: Fail ovirt job session
           ovirt_job:
             auth: "{{ ovirt_auth }}"
-            description: "Upgrading hosts"
+            description: "Upgrading hosts in {{ cluster_name }}"
             state: failed
+
+        - name: progress 95% - host upgrades failed, only thing left is to start any non-migratable VMs stopped by the playbook
+          include_tasks: log_progress.yml
+          vars:
+            progress: 95
+            description: "hosts upgrades failed"
 
       always:
         - name: Set original cluster policy
@@ -164,14 +225,20 @@
             scheduling_policy_properties: "{{ cluster_scheduling_policy_properties }}"
           when: use_maintenance_policy and cluster_policy.changed | default(false)
 
+        - name: progress 95% - host upgrades are done (successful or not), only need to start VMs that were stopped by the playbook
+          include_tasks: log_progress.yml
+          vars:
+            progress: 95
+            description: "host upgrades are done (successful or not), restarting non-migratable VMs"
+
+        # TODO: These VMs aren't explicity stopped anywhere...should they be?
         - name: Start again stopped VMs
           ovirt_vm:
             auth: "{{ ovirt_auth }}"
             name: "{{ item }}"
             state: running
           ignore_errors: "yes"
-          with_items:
-            - "{{ stopped_vms | default([]) }}"
+          loop: "{{ stopped_vms | default([]) | flatten(levels=1) }}"
 
         - name: Start again pin to host VMs
           ovirt_vm:
@@ -179,32 +246,38 @@
             name: "{{ item }}"
             state: running
           ignore_errors: "yes"
-          with_items:
-            - "{{ pinned_vms_names | default([]) }}"
-          when: "stop_non_migratable_vms"
+          loop: "{{ pinned_vms_names | default([]) | flatten(levels=1) }}"
+          when: stop_non_migratable_vms
+
+        - name: progress 100% - host upgrades are done (successful or not), non-migratable VMs are started, everything is now done
+          include_tasks: log_progress.yml
+          vars:
+            progress: 100
+            description: "host upgrades are done, non-migratable VMs are restarted"
 
   always:
     - name: Set cluster upgrade status to finished
       no_log: true
       uri:
-        url: "{{ ovirt_auth.url }}/clusters/{{ cluster_info.ovirt_clusters[0].id }}/upgrade"
+        url: "{{ ovirt_auth.url }}/clusters/{{ cluster_id }}/upgrade"
         validate_certs: false
         method: POST
         body_format: json
         headers:
           Authorization: "Bearer {{ ovirt_auth.token }}"
+          Correlation-Id: "{{ engine_correlation_id }}"
         body:
           upgrade_action: finish
       when:
         - upgrade_set is defined and not upgrade_set.failed | default(false)
-        - api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 3
+        - api_gt43
 
     - name: Logout from oVirt
       ovirt_auth:
         state: absent
         ovirt_auth: "{{ ovirt_auth }}"
       when:
-        - login_result.skipped is defined and not login_result.skipped
+        - login_result.skipped is undefined or not login_result.skipped
         - provided_token != ovirt_auth.token
       tags:
         - always

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -231,6 +231,15 @@
             progress: 95
             description: "host upgrades are done (successful or not), restarting non-migratable VMs"
 
+        # TODO: These VMs aren't explicity stopped anywhere...should they be?
+        - name: Start again stopped VMs
+          ovirt_vm:
+            auth: "{{ ovirt_auth }}"
+            name: "{{ item }}"
+            state: running
+          ignore_errors: "yes"
+          loop: "{{ stopped_vms | default([]) | flatten(levels=1) }}"
+
         - name: Start again pin to host VMs
           ovirt_vm:
             auth: "{{ ovirt_auth }}"

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -64,7 +64,7 @@
         validate_certs: false
         headers:
           Authorization: "Bearer {{ ovirt_auth.token }}"
-          Correlation-Id: "{{ engine_correlation_id }}"
+          Correlation-Id: "{{ engine_correlation_id | default(omit) }}"
         body:
           upgrade_action: start
       when: api_gt43
@@ -265,7 +265,7 @@
         body_format: json
         headers:
           Authorization: "Bearer {{ ovirt_auth.token }}"
-          Correlation-Id: "{{ engine_correlation_id }}"
+          Correlation-Id: "{{ engine_correlation_id | default(omit) }}"
         body:
           upgrade_action: finish
       when:

--- a/roles/cluster_upgrade/tasks/upgrade.yml
+++ b/roles/cluster_upgrade/tasks/upgrade.yml
@@ -116,17 +116,6 @@
       steps:
         - description: "Upgrading host: {{ host_name }}"
 
-  # - name: Upgrade host (dummy)
-  #   debug:
-  #     msg:
-  #       - "Skipping!!"
-  #       - auth: "{{ ovirt_auth }}"
-  #       - name: "{{ host_name }}"
-  #       - state: upgraded
-  #       - check_upgrade: "{{ check_upgrade }}"
-  #       - reboot_after_upgrade: "{{ reboot_after_upgrade }}"
-  #       - timeout: "{{ upgrade_timeout }}"
-
   - name: Upgrade host
     ovirt_host:
       auth: "{{ ovirt_auth }}"

--- a/roles/cluster_upgrade/tasks/upgrade.yml
+++ b/roles/cluster_upgrade/tasks/upgrade.yml
@@ -1,98 +1,165 @@
-- name: Get list of VMs in host
-  ovirt_vm_info:
-    auth: "{{ ovirt_auth }}"
-    pattern: "cluster={{ cluster_name }} and host={{ item.name }} and status=up"
-  check_mode: "no"
+---
+# Upgrade uses a block to keep the variables local to the block.  Vars are defined after tasks.
+- block:
 
-- name: Move user migratable vms
-  ovirt_vm:
-    auth: "{{ ovirt_auth }}"
-    force_migrate: true
-    migrate: true
-    state: running
-    name: "{{ item.name }}"
-  register: resp
-  when:
-    - "item['placement_policy']['affinity'] == 'user_migratable'"
-  with_items:
-    - "{{ vms_in_cluster.ovirt_vms }}"
-  loop_control:
-    label: "{{ item.name }}"
+  - name: Start prep host ovirt job step
+    ovirt_job:
+      auth: "{{ ovirt_auth }}"
+      description: "Upgrading hosts in {{ cluster_name }}"
+      steps:
+        - description: "Preparing host for upgrade: {{ host_name }}"
 
-- name: Shutdown non-migratable VMs
-  ovirt_vm:
-    auth: "{{ ovirt_auth }}"
-    state: stopped
-    force: true
-    name: "{{ item.name }}"
-  with_items:
-    - "{{ vms_in_cluster.ovirt_vms }}"
-  when:
-    - "item['placement_policy']['affinity'] == 'pinned'"
-  loop_control:
-    label: "{{ item.name }}"
-  register: pinned_to_host_vms
+  - name: progress - prepare host for upgrade (upgrade can't start until no VMs are running on the host)
+    include_tasks: log_progress.yml
+    vars:
+      progress: "{{ progress_host_start|int }}"
+      description: "preparing host for upgrade"
 
-- name: Create list of VM names which was shutted down
-  set_fact:
-    pinned_vms_names: "{{ pinned_vms_names + pinned_to_host_vms.results | selectattr('changed') | map(attribute='item.name') | list }}"
+  - name: Get list of VMs in host
+    ovirt_vm_info:
+      auth: "{{ ovirt_auth }}"
+      pattern: "cluster={{ cluster_name }} and host={{ host_name }} and status=up"
+    check_mode: "no"
 
-- name: Start ovirt job step
-  ovirt_job:
-    auth: "{{ ovirt_auth }}"
-    description: "Upgrading hosts"
-    steps:
-      - description: "Upgrading host: {{ item.name }}"
+  - name: Move user migratable vms
+    ovirt_vm:
+      auth: "{{ ovirt_auth }}"
+      force_migrate: true
+      migrate: true
+      state: running
+      name: "{{ item.name }}"
+    register: resp
+    when:
+      - "item['placement_policy']['affinity'] == 'user_migratable'"
+    with_items:
+      - "{{ vms_in_cluster.ovirt_vms }}"
+    loop_control:
+      label: "{{ item.name }}"
 
-- name: Gather self-heal facts about all gluster hosts in the cluster
-  ansible.builtin.shell: gluster volume heal {{ volume_item.name }} info
-  register: self_heal_status
-  retries: "{{ healing_in_progress_checks }}"
-  delay: "{{ healing_in_progress_check_delay }}"
-  until: >
-     self_heal_status.stdout_lines is defined and
-     self_heal_status.stdout_lines | select('match','^(Number of entries: )[0-9]+') | map('last') | map('int') | sum == 0
-  delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
-  connection: ssh
-  with_items:
-    - "{{ cluster_info.ovirt_clusters[0].gluster_volumes }}"
-  loop_control:
-    loop_var: volume_item
-  when:  cluster_info.ovirt_clusters[0].gluster_service | bool
+  - name: progress - done migrating VMs (host 10% complete)
+    include_tasks: log_progress.yml
+    vars:
+      progress: "{{ (progress_host_start|int + (progress_host_step_size|int * 0.10)) | int }}"
+      description: "status=up VMs migrated off host"
 
-- name: Refresh gluster heal info entries to database
-  uri:
-    url: "{{ ovirt_auth.url }}/clusters/{{ cluster_info.ovirt_clusters[0].id }}/refreshglusterhealstatus"
-    method: POST
-    body_format: json
-    validate_certs: false
-    headers:
-      Authorization: "Bearer {{ ovirt_auth.token }}"
-    body: "{}"
-  when:
-    - cluster_info.ovirt_clusters[0].gluster_service | bool
-    - api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 4
+  - name: Shutdown non-migratable VMs
+    ovirt_vm:
+      auth: "{{ ovirt_auth }}"
+      state: stopped
+      force: true
+      name: "{{ item.name }}"
+    with_items:
+      - "{{ vms_in_cluster.ovirt_vms }}"
+    when:
+      - "item['placement_policy']['affinity'] == 'pinned'"
+    loop_control:
+      label: "{{ item.name }}"
+    register: pinned_to_host_vms
 
-- name: Upgrade host
-  ovirt_host:
-    auth: "{{ ovirt_auth }}"
-    name: "{{ item.name }}"
-    state: upgraded
-    check_upgrade: "{{ check_upgrade }}"
-    reboot_after_upgrade: "{{ reboot_after_upgrade }}"
-    timeout: "{{ upgrade_timeout }}"
+  - name: Create list of VM names which have been shut down
+    set_fact:
+      pinned_vms_names: "{{ pinned_vms_names + pinned_to_host_vms.results | selectattr('changed') | map(attribute='host_name') | list }}"
 
-- name: Delay in minutes to wait to finish gluster healing process after successful host upgrade
-  pause:
-    minutes: "{{ wait_to_finish_healing }}"
-  when:
-    - cluster_info.ovirt_clusters[0].gluster_service | bool
-    - host_info.ovirt_hosts | length > 1
+  - name: progress - done shutting down pinned VMs (host 20% complete)
+    include_tasks: log_progress.yml
+    vars:
+      progress: "{{ (progress_host_start|int + (progress_host_step_size|int * 0.20)) | int }}"
+      description: "pinned VMs shutdown"
 
-- name: Finish ovirt job step
-  ovirt_job:
-    auth: "{{ ovirt_auth }}"
-    description: "Upgrading hosts"
-    steps:
-      - description: "Upgrading host: {{ item.name }}"
-        state: finished
+  - name: Gather self-heal facts about all gluster hosts in the cluster
+    ansible.builtin.shell: gluster volume heal {{ volume_item.name }} info
+    register: self_heal_status
+    retries: "{{ healing_in_progress_checks }}"
+    delay: "{{ healing_in_progress_check_delay }}"
+    until: >
+      self_heal_status.stdout_lines is defined and
+      self_heal_status.stdout_lines | select('match','^(Number of entries: )[0-9]+') | map('last') | map('int') | sum == 0
+    delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
+    connection: ssh
+    with_items:
+      - "{{ cluster_info.ovirt_clusters[0].gluster_volumes }}"
+    loop_control:
+      loop_var: volume_item
+    when:  cluster_info.ovirt_clusters[0].gluster_service | bool
+
+  - name: Refresh gluster heal info entries to database
+    uri:
+      url: "{{ ovirt_auth.url }}/clusters/{{ cluster_id }}/refreshglusterhealstatus"
+      method: POST
+      body_format: json
+      validate_certs: false
+      headers:
+        Authorization: "Bearer {{ ovirt_auth.token }}"
+      body: "{}"
+    when:
+      - cluster_info.ovirt_clusters[0].gluster_service | bool
+      - api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 4
+
+  - name: progress - host is ready for upgrade (host 30% complete)
+    include_tasks: log_progress.yml
+    vars:
+      progress: "{{ (progress_host_start|int + (progress_host_step_size|int * 0.30)) | int }}"
+      description: "host is ready for upgrade"
+
+  - name: Finish prep host ovirt job step
+    ovirt_job:
+      auth: "{{ ovirt_auth }}"
+      description: "Upgrading hosts in {{ cluster_name }}"
+      steps:
+        - description: "Preparing host for upgrade: {{ host_name }}"
+          state: finished
+
+  - name: Start upgrade host ovirt job step
+    ovirt_job:
+      auth: "{{ ovirt_auth }}"
+      description: "Upgrading hosts in {{ cluster_name }}"
+      steps:
+        - description: "Upgrading host: {{ host_name }}"
+
+  # - name: Upgrade host (dummy)
+  #   debug:
+  #     msg:
+  #       - "Skipping!!"
+  #       - auth: "{{ ovirt_auth }}"
+  #       - name: "{{ host_name }}"
+  #       - state: upgraded
+  #       - check_upgrade: "{{ check_upgrade }}"
+  #       - reboot_after_upgrade: "{{ reboot_after_upgrade }}"
+  #       - timeout: "{{ upgrade_timeout }}"
+
+  - name: Upgrade host
+    ovirt_host:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ host_name }}"
+      state: upgraded
+      check_upgrade: "{{ check_upgrade }}"
+      reboot_after_upgrade: "{{ reboot_after_upgrade }}"
+      timeout: "{{ upgrade_timeout }}"
+
+  - name: Delay in minutes to wait to finish gluster healing process after successful host upgrade
+    pause:
+      minutes: "{{ wait_to_finish_healing }}"
+    when:
+      - cluster_info.ovirt_clusters[0].gluster_service | bool
+      - host_info.ovirt_hosts | length > 1
+
+  - name: progress - host upgrade complete (host 100% complete)
+    include_tasks: log_progress.yml
+    vars:
+      progress: "{{ (progress_host_start|int + (progress_host_step_size|int * 1.00)) | int }}"
+      description: "host upgrade complete"
+
+  - name: Finish upgrade host ovirt job step
+    ovirt_job:
+      auth: "{{ ovirt_auth }}"
+      description: "Upgrading hosts in {{ cluster_name }}"
+      steps:
+        - description: "Upgrading host: {{ host_name }}"
+          state: finished
+
+  vars:
+    host_name: "{{ host.name }}"
+    my_step: "{{ ansible_loop.index | int }}"
+    progress_host_step_size: "{{ ((progress_end - progress_start) / ansible_loop.length) | round | int }}"
+    progress_host_start: "{{ progress_start|int + (progress_host_step_size|int * (my_step|int - 1)) }}"
+    progress_host_end: "{{ progress_start|int + (progress_host_step_size|int * my_step|int) }}"


### PR DESCRIPTION
Since cluster upgrade is a very long running process, adding progress tracking allows users and admins to easily track status.  Progress tracking is done by posting well formatted events.

Note: `roles/cluster_upgrade/tasks/upgrade.yml` was converted to a block.  This allows calculating var the tasks for a host upgrade needs without using `set_fact` style global facts.  The only annoyance is having to put them at the bottom of the file below all of the tasks.

Bug-Url: https://bugzilla.redhat.com/2040474
Signed-off-by: Scott J Dickerson <sdickers@redhat.com>