### PR TITLE
Add no_log to Manage VMs state task

### DIFF
--- a/changelogs/fragments/417-add-no_log-to-manage-vms-state-task.yml
+++ b/changelogs/fragments/417-add-no_log-to-manage-vms-state-task.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vm_infra - Add no_log to Manage VMs state task (https://github.com/oVirt/ovirt-ansible-collection/pull/417).

--- a/roles/vm_infra/tasks/vm_state_present.yml
+++ b/roles/vm_infra/tasks/vm_state_present.yml
@@ -97,6 +97,7 @@
   with_items: "{{ create_sensitive_vms }}"
   loop_control:
     loop_var: "current_vm"
+  no_log: true
 
 - name: Wait for VMs to be started
   no_log: "{{ not debug_vm_create }}"


### PR DESCRIPTION
"Manage VMs state" task is disclosing sensitive datas into logs (cloud-init root_password)