### PR TITLE
ovirt_qos, ovirt_disk_profile, ovirt_disk: Add modules to allow for creation and updating of disk_profiles

### DIFF
--- a/changelogs/fragments/422-add-qos-and-disk_profle.yml
+++ b/changelogs/fragments/422-add-qos-and-disk_profle.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ovirt_qos, ovirt_disk_profile, ovirt_disk - Add modules to allow for creation and updating of disk_profiles (https://github.com/oVirt/ovirt-ansible-collection/pull/422).

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -729,7 +729,7 @@ class DisksModule(BaseModule):
             equal(self.param('propagate_errors'), entity.propagate_errors) and
             equal(otypes.ScsiGenericIO(self.param('scsi_passthrough')) if self.param('scsi_passthrough') else None, entity.sgio) and
             equal(self.param('wipe_after_delete'), entity.wipe_after_delete) and
-            equal(self.param('profile'), entity.disk_profile)
+            equal(self.param('profile'), getattr(entity.disk_profile, 'name', None))
         )
 
 

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -729,7 +729,7 @@ class DisksModule(BaseModule):
             equal(self.param('propagate_errors'), entity.propagate_errors) and
             equal(otypes.ScsiGenericIO(self.param('scsi_passthrough')) if self.param('scsi_passthrough') else None, entity.sgio) and
             equal(self.param('wipe_after_delete'), entity.wipe_after_delete) and
-            equal(self.param('profile'), getattr(entity.disk_profile, 'name', None))
+            equal(self.param('profile'), follow_link(self._connection, entity.disk_profile).name)
         )
 
 

--- a/plugins/modules/ovirt_disk_profile.py
+++ b/plugins/modules/ovirt_disk_profile.py
@@ -1,15 +1,20 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
 module: ovirt_disk_profile
-short_description: "Module to manage storage domain disk profiles in oVirt/RHV"
+short_description: "Module to manage storage domain disk profiles in @NAME@"
 author:
 - "Niall O Donnell (niall.odonnell@ppb.com)"
 description:
-    - "Module to manage storage domain disk profiles in oVirt/RHV."
+    - "Module to manage storage domain disk profiles in @NAME@."
 options:
     id:
         description:
@@ -33,7 +38,7 @@ options:
         type: str
     qos:
         description:
-            - "Name of the QoS entry on the disk profile. If not passed defaults to oVirt/RHV HE default"
+            - "Name of the QoS entry on the disk profile. If not passed defaults to @NAME@ HE default"
         type: str
     state:
         description:
@@ -46,7 +51,7 @@ extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
 
 EXAMPLES = '''
 # Create a new disk profile on storage_domain_01 using the test_qos QoS in the Default datacenter
-- ovirt_disk_profile:
+- @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"
@@ -55,7 +60,7 @@ EXAMPLES = '''
     qos: "test_qos"
 
 # Create a new disk profile on storage_domain_01 in the Default datacenter using the HE default qos
-- ovirt_disk_profile:
+- @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"
@@ -63,7 +68,7 @@ EXAMPLES = '''
     storage_domain: "storage_domain_01"
 
 # Remove the test_qos disk profile
-- ovirt_disk_profile:
+- @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"
@@ -101,6 +106,7 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
     get_entity
 )
 
+
 class DiskProfileModule(BaseModule):
 
     def _get_qos(self):
@@ -124,8 +130,6 @@ class DiskProfileModule(BaseModule):
 
         if qos is None:
             qos = get_entity(qos_service.service(self._module.params.get('qos')))
-            if qos is None:
-                return None
 
         return qos
 
@@ -141,11 +145,8 @@ class DiskProfileModule(BaseModule):
 
         if storage_domain is None:
             storage_domain = get_entity(storage_domains_service.service(storage_domain_name))
-            if storage_domain is None:
-                return None
 
         return storage_domain
-
 
     def build_entity(self):
         """
@@ -174,8 +175,6 @@ class DiskProfileModule(BaseModule):
             storage_domain=storage_domain,
         )
 
-
-
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
@@ -200,7 +199,6 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
 
-
         disk_profiles_service = connection.system_service().disk_profiles_service()
 
         disk_profile_module = DiskProfileModule(
@@ -220,6 +218,6 @@ def main():
     finally:
         connection.close(logout=auth.get('token') is None)
 
-if __name__ == "__main__":
-  main()
 
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ovirt_disk_profile.py
+++ b/plugins/modules/ovirt_disk_profile.py
@@ -28,6 +28,10 @@ options:
         description:
             - "Description of the disk profile."
         type: str
+    comment:
+        description:
+            - "Comment of the disk profile."
+        type: str
     storage_domain:
         description:
             - "Name of the storage domain where the disk profile should be created."
@@ -167,6 +171,7 @@ def main():
         ),
         id=dict(default=None),
         name=dict(default=None),
+        comment=dict(default=None),
         storage_domain=dict(default=None),
         data_center=dict(default=None),
         qos=dict(default=None),

--- a/plugins/modules/ovirt_disk_profile.py
+++ b/plugins/modules/ovirt_disk_profile.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 module: ovirt_disk_profile
 short_description: "Module to manage storage domain disk profiles in @NAME@"
 author:
-- "Niall O Donnell (niall.odonnell@ppb.com)"
+- "Niall O Donnell (@odonnelln)"
 description:
     - "Module to manage storage domain disk profiles in @NAME@."
 options:
@@ -120,7 +120,6 @@ class DiskProfileModule(BaseModule):
         qos_service = dcs_service.data_center_service(get_id_by_name(dcs_service, dc_name)).qoss_service()
         return get_entity(qos_service.qos_service(get_id_by_name(qos_service, self._module.params.get('qos'))))
 
-
     def _get_storage_domain(self):
         """
         Gets the storage domain
@@ -144,20 +143,21 @@ class DiskProfileModule(BaseModule):
 
         if qos is None:
             raise Exception(
-                f"The qos: {self._module.params.get('qos')} does not exist in data center: {self._module.params.get('data_center')}"
+                "The qos: {0} does not exist in data center: {1}".format(self._module.params.get('qos'), self._module.params.get('data_center'))
             )
         if storage_domain is None:
             raise Exception(
-                f"The storage domain: {self._module.params.get('storage_domain')} does not exist."
+                "The storage domain: {0} does not exist.".format(self._module.params.get('storage_domain'))
             )
         return otypes.DiskProfile(
             name=self._module.params.get('name') if self._module.params.get('name') else None,
-            id = self._module.params.get('id') if self._module.params.get('id') else None,
+            id=self._module.params.get('id') if self._module.params.get('id') else None,
             comment=self._module.params.get('comment'),
             description=self._module.params.get('description'),
             qos=qos,
             storage_domain=storage_domain,
         )
+
 
 def main():
     argument_spec = ovirt_full_argument_spec(

--- a/plugins/modules/ovirt_disk_profile.py
+++ b/plugins/modules/ovirt_disk_profile.py
@@ -1,0 +1,225 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ovirt_disk_profile
+short_description: "Module to manage storage domain disk profiles in oVirt/RHV"
+author:
+- "Niall O Donnell (niall.odonnell@ppb.com)"
+description:
+    - "Module to manage storage domain disk profiles in oVirt/RHV."
+options:
+    id:
+        description:
+            - "ID of the disk profile to manage. Either C(id) or C(name) is required."
+        type: str
+    name:
+        description:
+            - "Name of the disk profile to manage. Either C(id) or C(name)/C(alias) is required."
+        type: str
+    description:
+        description:
+            - "Description of the disk profile."
+        type: str
+    storage_domain:
+        description:
+            - "Name of the storage domain where the disk profile should be created."
+        type: str
+    data_center:
+        description:
+            - "Name of the data center where the qos entry has been created."
+        type: str
+    qos:
+        description:
+            - "Name of the QoS entry on the disk profile. If not passed defaults to oVirt/RHV HE default"
+        type: str
+    state:
+        description:
+            - "Should the disk profile be present/absent."
+        choices: ['present', 'absent']
+        default: 'present'
+        type: str
+extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
+'''
+
+EXAMPLES = '''
+# Create a new disk profile on storage_domain_01 using the test_qos QoS in the Default datacenter
+- ovirt_disk_profile:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_disk_profile"
+    state: "present"
+    storage_domain: "storage_domain_01"
+    qos: "test_qos"
+
+# Create a new disk profile on storage_domain_01 in the Default datacenter using the HE default qos
+- ovirt_disk_profile:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_disk_profile"
+    state: "present"
+    storage_domain: "storage_domain_01"
+
+# Remove the test_qos disk profile
+- ovirt_disk_profile:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_disk_profile"
+    state: "absent"
+    storage_domain: "storage_domain_01"
+    qos: "test_qos"
+'''
+
+RETURN = '''
+id:
+    description: "ID of the managed disk profile"
+    returned: "On success if disk profile is found."
+    type: str
+    sample: 7de90f31-222c-436c-a1ca-7e655bd5b60c
+disk_profile:
+    description: "Dictionary of all the disk profile attributes. Disk profile attributes can be found on your oVirt/RHV instance
+                  at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/disk_profile."
+    returned: "On success if disk profile is found."
+    type: dict
+'''
+try:
+    import ovirtsdk4.types as otypes
+except ImportError:
+    pass
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
+    BaseModule,
+    check_sdk,
+    create_connection,
+    ovirt_full_argument_spec,
+    search_by_name,
+    get_entity
+)
+
+class DiskProfileModule(BaseModule):
+
+    def _get_qos(self):
+        """
+        Gets the QoS entry if exists
+
+        :return: otypes.QoS or None
+        """
+        dc_name = self._module.params.get('data_center')
+        dcs_service = self._connection.system_service().data_centers_service()
+        dc = search_by_name(dcs_service, dc_name)
+
+        if dc is None:
+            dc = get_entity(dcs_service.service(dc_name))
+            if dc is None:
+                return None
+
+        dc_service = dcs_service.data_center_service(dc.id)
+        qos_service = dc_service.qoss_service()
+        qos = search_by_name(qos_service, self._module.params.get('qos'))
+
+        if qos is None:
+            qos = get_entity(qos_service.service(self._module.params.get('qos')))
+            if qos is None:
+                return None
+
+        return qos
+
+    def _get_storage_domain(self):
+        """
+        Gets the storage domain
+
+        :return: otypes.StorageDomain or None
+        """
+        storage_domain_name = self._module.params.get('storage_domain')
+        storage_domains_service = self._connection.system_service().storage_domains_service()
+        storage_domain = search_by_name(storage_domains_service, storage_domain_name)
+
+        if storage_domain is None:
+            storage_domain = get_entity(storage_domains_service.service(storage_domain_name))
+            if storage_domain is None:
+                return None
+
+        return storage_domain
+
+
+    def build_entity(self):
+        """
+        Abstract method from BaseModule called from create() and remove()
+
+        Builds the disk profile from the given params
+
+        :return: otypes.DiskProfile
+        """
+        qos = self._get_qos()
+        storage_domain = self._get_storage_domain()
+
+        if qos is None:
+            raise Exception(
+                f"The qos: {self._module.params.get('qos')} does not exist in data center: {self._module.params.get('data_center')}"
+            )
+        if storage_domain is None:
+            raise Exception(
+                f"The storage domain: {self._module.params.get('storage_domain')} does not exist."
+            )
+        return otypes.DiskProfile(
+            name=self._module.params.get('id') if self._module.params.get('id') else self._module.params.get('name'),
+            comment=self._module.params.get('comment'),
+            description=self._module.params.get('description'),
+            qos=qos,
+            storage_domain=storage_domain,
+        )
+
+
+
+def main():
+    argument_spec = ovirt_full_argument_spec(
+        state=dict(
+            choices=['present', 'absent'],
+            default='present',
+        ),
+        id=dict(default=None),
+        name=dict(default=None),
+        storage_domain=dict(default=None),
+        data_center=dict(default=None),
+        qos=dict(default=None),
+        description=dict(default=None)
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[['id', 'name']],
+    )
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+
+
+        disk_profiles_service = connection.system_service().disk_profiles_service()
+
+        disk_profile_module = DiskProfileModule(
+            connection=connection,
+            module=module,
+            service=disk_profiles_service,
+        )
+        state = module.params.get('state')
+        if state == 'present':
+            ret = disk_profile_module.create()
+        elif state == 'absent':
+            ret = disk_profile_module.remove()
+
+        module.exit_json(**ret)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+if __name__ == "__main__":
+  main()
+

--- a/plugins/modules/ovirt_disk_profile.py
+++ b/plugins/modules/ovirt_disk_profile.py
@@ -54,8 +54,8 @@ extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
 '''
 
 EXAMPLES = '''
-# Create a new disk profile on storage_domain_01 using the test_qos QoS in the Default datacenter
-- @NAMESPACE@.@NAME@.ovirt_disk_profile:
+- name: Create a new disk profile on storage_domain_01 using the test_qos QoS in the Default datacenter
+  @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"
@@ -63,16 +63,16 @@ EXAMPLES = '''
     storage_domain: "storage_domain_01"
     qos: "test_qos"
 
-# Create a new disk profile on storage_domain_01 in the Default datacenter using the HE default qos
-- @NAMESPACE@.@NAME@.ovirt_disk_profile:
+- name: Create a new disk profile on storage_domain_01 in the Default datacenter using the HE default qos
+  @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"
     state: "present"
     storage_domain: "storage_domain_01"
 
-# Remove the test_qos disk profile
-- @NAMESPACE@.@NAME@.ovirt_disk_profile:
+- name: Remove the test_qos disk profile
+  @NAMESPACE@.@NAME@.ovirt_disk_profile:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_disk_profile"

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -72,37 +72,37 @@ options:
     inbound_average:
         description:
             - "The desired average inbound bit rate in Mbps (Megabits per sec)."
-            - "Used to configure virtual machines networks. If defined, `inbound_peak` and `inbound_burst` also has to be set."
+            - "Used to configure virtual machines networks. If defined, C(inbound_peak) and C(inbound_burst) also has to be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     inbound_peak:
         description:
             - "The maximum inbound rate in Mbps (Megabits per sec)."
-            - "Used to configure virtual machines networks. If defined, `inbound_average` and `inbound_burst` also has to be set."
+            - "Used to configure virtual machines networks. If defined, C(inbound_average) and C(inbound_burst) also has to be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     inbound_burst:
         description:
             - "The amount of data that can be delivered in a single burst, in MB."
-            - "Used to configure virtual machine networks. If defined, `inbound_average` and `inbound_peak` must also be set."
+            - "Used to configure virtual machine networks. If defined, C(inbound_average) and C(inbound_peak) must also be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     outbound_average:
         description:
             - "The desired average outbound bit rate in Mbps (Megabits per sec)."
-            - "Used to configure virtual machines networks. If defined, `outbound_peak` and `outbound_burst` also has to be set."
+            - "Used to configure virtual machines networks. If defined, C(outbound_peak) and C(outbound_burst) also has to be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     outbound_peak:
         description:
             - "The maximum outbound rate in Mbps (Megabits per sec)."
-            - "Used to configure virtual machines networks. If defined, `outbound_average` and `outbound_burst` also has to be set."
+            - "Used to configure virtual machines networks. If defined, C(outbound_average) and C(outbound_burst) also has to be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     outbound_burst:
         description:
             - "The amount of data that can be sent in a single burst, in MB."
-            - "Used to configure virtual machine networks. If defined, `outbound_average` and `outbound_peak` must also be set."
+            - "Used to configure virtual machine networks. If defined, C(outbound_average) and C(outbound_peak) must also be set."
             - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
         type: int
     outbound_average_linkshare:
@@ -115,8 +115,8 @@ options:
     outbound_average_upperlimit:
         description:
             - "The maximum bandwidth to be used by a network in Mbps (Megabits per sec)."
-            - "Used to configure host networks. If `outboundAverageUpperlimit` and
-              `outbound_average_realtime` are provided, the `outbound_averageUpperlimit` must not be lower than the `outbound_average_realtime`."
+            - "Used to configure host networks. If C(outboundAverageUpperlimit) and
+              C(outbound_average_realtime) are provided, the C(outbound_averageUpperlimit) must not be lower than the C(outbound_average_realtime)."
         type: int
     outbound_average_realtime:
         description:
@@ -127,8 +127,8 @@ options:
         type: int
     type:
         description:
-            - "The type of QoS. Allows for one of storage/cpu/network/hostnetwork"
-            - "WARNING: Currently only works for storage"
+            - "The type of QoS."
+        choices: ['storage', 'cpu', 'network', 'hostnetwork']
         type: str
     state:
         description:
@@ -296,7 +296,10 @@ def main():
         outbound_average_linkshare=dict(default=None, type='int'),
         outbound_average_upperlimit=dict(default=None, type='int'),
         outbound_average_realtime=dict(default=None, type='int'),
-        type=dict(default=None)
+        type=dict(
+            choices=['storage', 'cpu', 'network', 'hostnetwork'],
+            default=None,
+        )
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -306,6 +309,10 @@ def main():
             ['max_iops', 'write_iops'],
             ['max_throughput', 'read_throughput'],
             ['max_throughput', 'write_throughput']
+        ],
+        required_together=[
+            ['inbound_average', 'inbound_peak', 'inbound_burst'],
+            ['outbound_average', 'outbound_peak', 'outbound_burst'],
         ]
     )
 

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -1,15 +1,20 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
 module: ovirt_qos
-short_description: "Module to manage QoS entries in oVirt/RHV"
+short_description: "Module to manage QoS entries in @NAME@"
 author:
 - "Niall O Donnell (niall.odonnell@ppb.com)"
 description:
-    - "Module to manage QoS entries in oVirt/RHV."
+    - "Module to manage QoS entries in @NAME@."
     - "Doesn't support updating a QoS that exists"
     - "Only works with storage QoS entries atm"
 options:
@@ -29,12 +34,6 @@ options:
         description:
             - "Name of the data center where the QoS entry should be created."
         type: str
-        max_iops=dict(default=None),
-        read_iops=dict(default=None),
-        write_iops=dict(default=None),
-        max_throughput=dict(default=None),
-        read_throughput=dict(default=None),
-        write_throughput=dict(default=None),
     max_iops:
         description:
             - "The max number of read/write iops. If passed you can't pass a value for C(read_iops) or C(write_iops)"
@@ -81,7 +80,7 @@ extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
 
 EXAMPLES = '''
 # Create a new storage QoS with default values for max_iops and max_throughput
-- ovirt_qos:
+- @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -89,7 +88,7 @@ EXAMPLES = '''
     type: "storage"
 
 # Create a new storage QoS with default values for max_iops and read_throughput but 100 for write throughput
-- ovirt_qos:
+- @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -98,7 +97,7 @@ EXAMPLES = '''
     write_throughput: 100
 
 # Create a new storage QoS with default values for write_iops and max_throughput but 100 for read iops
-- ovirt_qos:
+- @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -107,7 +106,7 @@ EXAMPLES = '''
     read_iops: 100
 
 # Create a new storage QoS with 100 max_iops and 200 max_throughput
-- ovirt_qos:
+- @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -117,7 +116,7 @@ EXAMPLES = '''
     max_throughput: 100
 
 # Remove a storage QoS
-- ovirt_qos:
+- @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -132,7 +131,7 @@ id:
     type: str
     sample: 7de90f31-222c-436c-a1ca-7e655bd5b60c
 qos:
-    description: "Dictionary of all the QoS attributes. QoS attributes can be found on your oVirt/RHV instance
+    description: "Dictionary of all the QoS attributes. QoS attributes can be found on your @NAME@ instance
                   at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/qos."
     returned: "On success if QoS is found."
     type: dict
@@ -154,6 +153,7 @@ from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
     get_entity
 )
 
+
 class QosModule(BaseModule):
 
     def _get_qos_type(self, type):
@@ -165,8 +165,7 @@ class QosModule(BaseModule):
             return otypes.QosType.HOSTNETWORK
         elif type == 'cpu':
             return otypes.QosType.CPU
-        else:
-            return None
+        return None
 
     def build_entity(self):
         """
@@ -188,6 +187,7 @@ class QosModule(BaseModule):
             max_write_throughput=int(self._module.params.get('write_throughput')) if self._module.params.get('write_throughput') is not None else None,
         )
 
+
 def _get_qoss_service(connection, dc_name):
     """
     Gets the qoss_service from the data_center provided
@@ -200,7 +200,7 @@ def _get_qoss_service(connection, dc_name):
     if dc is None:
         dc = get_entity(dcs_service.service(dc_name))
         if dc is None:
-            return None
+            raise Exception('Datacenter not found')
 
     dc_service = dcs_service.data_center_service(dc.id)
     return dc_service.qoss_service()
@@ -228,9 +228,9 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[['id', 'name']],
         mutually_exclusive=[
-            ['max_iops','read_iops'],
+            ['max_iops', 'read_iops'],
             ['max_iops', 'write_iops'],
-            ['max_throughput','read_throughput'],
+            ['max_throughput', 'read_throughput'],
             ['max_throughput', 'write_througput']
         ]
     )
@@ -259,6 +259,6 @@ def main():
     finally:
         connection.close(logout=auth.get('token') is None)
 
-if __name__ == "__main__":
-  main()
 
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -64,6 +64,67 @@ options:
             - "The max number of read throughput. If passed you can't pass a value for C(max_throughput)"
             - "If no value is given it will default to the HE value, assuming C(max_throughput) hasn't been set"
         type: int
+    cpu_limit:
+        description:
+            - "The maximum processing capability in %."
+            - "Used to configure computing resources."
+        type: int
+    inbound_average:
+        description:
+            - "The desired average inbound bit rate in Mbps (Megabits per sec)."
+            - "Used to configure virtual machines networks. If defined, `inbound_peak` and `inbound_burst` also has to be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    inbound_peak:
+        description:
+            - "The maximum inbound rate in Mbps (Megabits per sec)."
+            - "Used to configure virtual machines networks. If defined, `inbound_average` and `inbound_burst` also has to be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    inbound_burst:
+        description:
+            - "The amount of data that can be delivered in a single burst, in MB."
+            - "Used to configure virtual machine networks. If defined, `inbound_average` and `inbound_peak` must also be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    outbound_average:
+        description:
+            - "The desired average outbound bit rate in Mbps (Megabits per sec)."
+            - "Used to configure virtual machines networks. If defined, `outbound_peak` and `outbound_burst` also has to be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    outbound_peak:
+        description:
+            - "The maximum outbound rate in Mbps (Megabits per sec)."
+            - "Used to configure virtual machines networks. If defined, `outbound_average` and `outbound_burst` also has to be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    outbound_burst:
+        description:
+            - "The amount of data that can be sent in a single burst, in MB."
+            - "Used to configure virtual machine networks. If defined, `outbound_average` and `outbound_peak` must also be set."
+            - "See link:https://libvirt.org/formatnetwork.html#elementQoS[Libvirt-QOS] for further details."
+        type: int
+    outbound_average_linkshare:
+        description:
+            - "Weighted share."
+            - "Used to configure host networks. Signifies how much of the logical link's capacity a specific network should be
+              allocated, relative to the other networks attached to the same logical link. The exact share depends on the sum
+              of shares of all networks on that link. By default this is a number in the range 1-100."
+        type: int
+    outbound_average_upperlimit:
+        description:
+            - "The maximum bandwidth to be used by a network in Mbps (Megabits per sec)."
+            - "Used to configure host networks. If `outboundAverageUpperlimit` and
+              `outbound_average_realtime` are provided, the `outbound_averageUpperlimit` must not be lower than the `outbound_average_realtime`."
+        type: int
+    outbound_average_realtime:
+        description:
+            - "The committed rate in Mbps (Megabits per sec)."
+            - "Used to configure host networks. The minimum bandwidth required by a network. The committed rate requested is not
+               guaranteed and will vary depending on the network infrastructure and the committed rate requested by other
+               networks on the same logical link."
+        type: int
     type:
         description:
             - "The type of QoS. Allows for one of storage/cpu/network/hostnetwork"
@@ -177,16 +238,25 @@ class QosModule(BaseModule):
         :return: otypes.QoS
         """
         return otypes.Qos(
-            name=self._module.params.get('name') if self._module.params.get('name') else None,
-            id=self._module.params.get('id') if self._module.params.get('id') else None,
-            type=self._get_qos_type(self._module.params.get('type')),
-            description=self._module.params.get('description') if self._module.params.get('description') else None,
-            max_iops=self._module.params.get('max_iops') if self._module.params.get('max_iops') is not None else None,
-            max_read_iops=self._module.params.get('read_iops') if self._module.params.get('read_iops') is not None else None,
-            max_read_throughput=self._module.params.get('read_throughput') if self._module.params.get('read_throughput') is not None else None,
-            max_throughput=self._module.params.get('max_throughput') if self._module.params.get('max_throughput') is not None else None,
-            max_write_iops=self._module.params.get('write_iops') if self._module.params.get('write_iops') is not None else None,
-            max_write_throughput=self._module.params.get('write_throughput') if self._module.params.get('write_throughput') is not None else None,
+            name=self.param('name'),
+            id=self.param('id'),
+            type=self._get_qos_type(self.param('type')),
+            description=self.param('description'),
+            max_iops=self.param('max_iops'),
+            max_read_iops=self.param('read_iops'),
+            max_read_throughput=self.param('read_throughput'),
+            max_throughput=self.param('max_throughput'),
+            max_write_iops=self.param('write_iops'),
+            cpu_limit=self.param('cpu_limit'),
+            inbound_average=self.param('inbound_average'),
+            inbound_peak=self.param('inbound_peak'),
+            inbound_burst=self.param('inbound_burst'),
+            outbound_average=self.param('outbound_average'),
+            outbound_peak=self.param('outbound_peak'),
+            outbound_burst=self.param('outbound_burst'),
+            outbound_average_linkshare=self.param('outbound_average_linkshare'),
+            outbound_average_upperlimit=self.param('outbound_average_upperlimit'),
+            outbound_average_realtime=self.param('outbound_average_realtime'),
         )
 
 
@@ -216,6 +286,16 @@ def main():
         max_throughput=dict(default=None, type='int'),
         read_throughput=dict(default=None, type='int'),
         write_throughput=dict(default=None, type='int'),
+        cpu_limit=dict(default=None, type='int'),
+        inbound_average=dict(default=None, type='int'),
+        inbound_peak=dict(default=None, type='int'),
+        inbound_burst=dict(default=None, type='int'),
+        outbound_average=dict(default=None, type='int'),
+        outbound_peak=dict(default=None, type='int'),
+        outbound_burst=dict(default=None, type='int'),
+        outbound_average_linkshare=dict(default=None, type='int'),
+        outbound_average_upperlimit=dict(default=None, type='int'),
+        outbound_average_realtime=dict(default=None, type='int'),
         type=dict(default=None)
     )
     module = AnsibleModule(

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 module: ovirt_qos
 short_description: "Module to manage QoS entries in @NAME@"
 author:
-- "Niall O Donnell (niall.odonnell@ppb.com)"
+- "Niall O Donnell (@odonnelln)"
 description:
     - "Module to manage QoS entries in @NAME@."
     - "Doesn't support updating a QoS that exists"
@@ -178,7 +178,7 @@ class QosModule(BaseModule):
         """
         return otypes.Qos(
             name=self._module.params.get('name') if self._module.params.get('name') else None,
-            id = self._module.params.get('id') if self._module.params.get('id') else None,
+            id=self._module.params.get('id') if self._module.params.get('id') else None,
             type=self._get_qos_type(self._module.params.get('type')),
             description=self._module.params.get('description') if self._module.params.get('description') else None,
             max_iops=self._module.params.get('max_iops') if self._module.params.get('max_iops') is not None else None,
@@ -200,7 +200,6 @@ def _get_qoss_service(connection, dc_name):
     return dcs_service.data_center_service(get_id_by_name(dcs_service, dc_name)).qoss_service()
 
 
-
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
@@ -209,6 +208,7 @@ def main():
         ),
         id=dict(default=None),
         name=dict(default=None),
+        description=dict(default=None),
         data_center=dict(default=None),
         max_iops=dict(default=None, type='int'),
         read_iops=dict(default=None, type='int'),
@@ -225,7 +225,7 @@ def main():
             ['max_iops', 'read_iops'],
             ['max_iops', 'write_iops'],
             ['max_throughput', 'read_throughput'],
-            ['max_throughput', 'write_througput']
+            ['max_throughput', 'write_throughput']
         ]
     )
 

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -1,0 +1,264 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ovirt_qos
+short_description: "Module to manage QoS entries in oVirt/RHV"
+author:
+- "Niall O Donnell (niall.odonnell@ppb.com)"
+description:
+    - "Module to manage QoS entries in oVirt/RHV."
+    - "Doesn't support updating a QoS that exists"
+    - "Only works with storage QoS entries atm"
+options:
+    id:
+        description:
+            - "ID of the QoS to manage. Either C(id) or C(name) is required."
+        type: str
+    name:
+        description:
+            - "Name of QoS to manage. Either C(id) or C(name)/C(alias) is required."
+        type: str
+    description:
+        description:
+            - "Description of the QoS."
+        type: str
+    data_center:
+        description:
+            - "Name of the data center where the QoS entry should be created."
+        type: str
+        max_iops=dict(default=None),
+        read_iops=dict(default=None),
+        write_iops=dict(default=None),
+        max_throughput=dict(default=None),
+        read_throughput=dict(default=None),
+        write_throughput=dict(default=None),
+    max_iops:
+        description:
+            - "The max number of read/write iops. If passed you can't pass a value for C(read_iops) or C(write_iops)"
+            - "If no value is given it will default to the HE value, assuming C(read_iops) or C(write_iops) hasn't been set"
+        type: str
+    write_iops:
+        description:
+            - "The max number of write iops. If passed you can't pass a value for C(max_iops)"
+            - "If no value is given it will default to the HE value, assuming C(max_iops) hasn't been set"
+        type: str
+    read_iops:
+        description:
+            - "The max number of read iops. If passed you can't pass a value for C(max_iops)"
+            - "If no value is given it will default to the HE value, assuming C(max_iops) hasn't been set"
+        type: str
+    max_throughput:
+        description:
+            - "The max number of read/write throughput. If passed you can't pass a value for C(read_throughput) or C(write_throughput)"
+            - "If no value is given it will default to the HE value, assuming C(read_throughput) or C(write_throughput) hasn't been set"
+        type: str
+    write_throughput:
+        description:
+            - "The max number of write throughput. If passed you can't pass a value for C(max_throughput)"
+            - "If no value is given it will default to the HE value, assuming C(max_throughput) hasn't been set"
+        type: str
+    read_throughput:
+        description:
+            - "The max number of read throughput. If passed you can't pass a value for C(max_throughput)"
+            - "If no value is given it will default to the HE value, assuming C(max_throughput) hasn't been set"
+        type: str
+    type:
+        description:
+            - "The type of QoS. Allows for one of storage/cpu/network/hostnetwork"
+            - "WARNING: Currently only works for storage"
+        type: str
+    state:
+        description:
+            - "Should the QoS be present/absent."
+        choices: ['present', 'absent']
+        default: 'present'
+        type: str
+extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
+'''
+
+EXAMPLES = '''
+# Create a new storage QoS with default values for max_iops and max_throughput
+- ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_qos_01"
+    state: "present"
+    type: "storage"
+
+# Create a new storage QoS with default values for max_iops and read_throughput but 100 for write throughput
+- ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_qos_01"
+    state: "present"
+    type: "storage"
+    write_throughput: 100
+
+# Create a new storage QoS with default values for write_iops and max_throughput but 100 for read iops
+- ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_qos_01"
+    state: "present"
+    type: "storage"
+    read_iops: 100
+
+# Create a new storage QoS with 100 max_iops and 200 max_throughput
+- ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_qos_01"
+    state: "present"
+    type: "storage"
+    max_iops: 100
+    max_throughput: 100
+
+# Remove a storage QoS
+- ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    data_center: "Default"
+    name: "test_qos_01"
+    state: "absent"
+    type: "storage"
+'''
+
+RETURN = '''
+id:
+    description: "ID of the managed QoS"
+    returned: "On success if QoS is found."
+    type: str
+    sample: 7de90f31-222c-436c-a1ca-7e655bd5b60c
+qos:
+    description: "Dictionary of all the QoS attributes. QoS attributes can be found on your oVirt/RHV instance
+                  at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/qos."
+    returned: "On success if QoS is found."
+    type: dict
+'''
+try:
+    import ovirtsdk4.types as otypes
+except ImportError:
+    pass
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.@NAMESPACE@.@NAME@.plugins.module_utils.ovirt import (
+    BaseModule,
+    check_sdk,
+    create_connection,
+    ovirt_full_argument_spec,
+    search_by_name,
+    get_entity
+)
+
+class QosModule(BaseModule):
+
+    def _get_qos_type(self, type):
+        if type == 'storage':
+            return otypes.QosType.STORAGE
+        elif type == 'network':
+            return otypes.QosType.NETWORK
+        elif type == 'hostnetwork':
+            return otypes.QosType.HOSTNETWORK
+        elif type == 'cpu':
+            return otypes.QosType.CPU
+        else:
+            return None
+
+    def build_entity(self):
+        """
+        Abstract method from BaseModule called from create() and remove()
+
+        Builds the QoS from the given params
+
+        :return: otypes.QoS
+        """
+        return otypes.Qos(
+            name=self._module.params.get('id') if self._module.params.get('id') else self._module.params.get('name'),
+            type=self._get_qos_type(self._module.params.get('type')),
+            description=self._module.params.get('description') if self._module.params.get('description') else None,
+            max_iops=int(self._module.params.get('max_iops')) if self._module.params.get('max_iops') is not None else None,
+            max_read_iops=int(self._module.params.get('read_iops')) if self._module.params.get('read_iops') is not None else None,
+            max_read_throughput=int(self._module.params.get('read_throughput')) if self._module.params.get('read_throughput') is not None else None,
+            max_throughput=int(self._module.params.get('max_throughput')) if self._module.params.get('max_throughput') is not None else None,
+            max_write_iops=int(self._module.params.get('write_iops')) if self._module.params.get('write_iops') is not None else None,
+            max_write_throughput=int(self._module.params.get('write_throughput')) if self._module.params.get('write_throughput') is not None else None,
+        )
+
+def _get_qoss_service(connection, dc_name):
+    """
+    Gets the qoss_service from the data_center provided
+
+    :returns: ovirt.services.QossService or None
+    """
+    dcs_service = connection.system_service().data_centers_service()
+    dc = search_by_name(dcs_service, dc_name)
+
+    if dc is None:
+        dc = get_entity(dcs_service.service(dc_name))
+        if dc is None:
+            return None
+
+    dc_service = dcs_service.data_center_service(dc.id)
+    return dc_service.qoss_service()
+
+
+
+def main():
+    argument_spec = ovirt_full_argument_spec(
+        state=dict(
+            choices=['present', 'absent'],
+            default='present',
+        ),
+        id=dict(default=None),
+        name=dict(default=None),
+        data_center=dict(default=None),
+        max_iops=dict(default=None),
+        read_iops=dict(default=None),
+        write_iops=dict(default=None),
+        max_throughput=dict(default=None),
+        read_throughput=dict(default=None),
+        write_throughput=dict(default=None),
+        type=dict(default=None)
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[['id', 'name']],
+        mutually_exclusive=[
+            ['max_iops','read_iops'],
+            ['max_iops', 'write_iops'],
+            ['max_throughput','read_throughput'],
+            ['max_throughput', 'write_througput']
+        ]
+    )
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        qoss_service = _get_qoss_service(connection, module.params.get('data_center'))
+
+        qos_module = QosModule(
+            connection=connection,
+            module=module,
+            service=qoss_service,
+        )
+
+        if module.params.get('state') == 'present':
+            ret = qos_module.create()
+        elif module.params.get('state') == 'absent':
+            ret = qos_module.remove()
+
+        module.exit_json(**ret)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+if __name__ == "__main__":
+  main()
+

--- a/plugins/modules/ovirt_qos.py
+++ b/plugins/modules/ovirt_qos.py
@@ -140,16 +140,16 @@ extends_documentation_fragment: @NAMESPACE@.@NAME@.ovirt
 '''
 
 EXAMPLES = '''
-# Create a new storage QoS with default values for max_iops and max_throughput
-- @NAMESPACE@.@NAME@.ovirt_qos:
+- name: Create a new storage QoS with default values for max_iops and max_throughput
+  @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
     state: "present"
     type: "storage"
 
-# Create a new storage QoS with default values for max_iops and read_throughput but 100 for write throughput
-- @NAMESPACE@.@NAME@.ovirt_qos:
+- name: Create a new storage QoS with default values for max_iops and read_throughput but 100 for write throughput
+  @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -157,8 +157,8 @@ EXAMPLES = '''
     type: "storage"
     write_throughput: 100
 
-# Create a new storage QoS with default values for write_iops and max_throughput but 100 for read iops
-- @NAMESPACE@.@NAME@.ovirt_qos:
+- name: Create a new storage QoS with default values for write_iops and max_throughput but 100 for read iops
+  @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -166,8 +166,8 @@ EXAMPLES = '''
     type: "storage"
     read_iops: 100
 
-# Create a new storage QoS with 100 max_iops and 200 max_throughput
-- @NAMESPACE@.@NAME@.ovirt_qos:
+- name: Create a new storage QoS with 100 max_iops and 200 max_throughput
+  @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
@@ -176,13 +176,47 @@ EXAMPLES = '''
     max_iops: 100
     max_throughput: 100
 
-# Remove a storage QoS
-- @NAMESPACE@.@NAME@.ovirt_qos:
+- name: Remove a storage QoS
+  @NAMESPACE@.@NAME@.ovirt_qos:
     auth: "{{ ovirt_auth }}"
     data_center: "Default"
     name: "test_qos_01"
     state: "absent"
     type: "storage"
+
+- name: Add a network QoS
+  @NAMESPACE@.@NAME@.ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    name: "myqos"
+    data_center: "Default"
+    state: "present"
+    type: "network"
+    inbound_average: 10
+    inbound_peak: 10
+    inbound_burst: 10
+    outbound_average: 10
+    outbound_peak: 10
+    outbound_burst: 10
+
+- name: Add a hostnetwork QoS
+  @NAMESPACE@.@NAME@.ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    name: "myqos"
+    data_center: "Default"
+    state: "present"
+    type: "hostnetwork"
+    outbound_average_linkshare: 10
+    outbound_average_upperlimit: 100
+    outbound_average_realtime: 50
+
+- name: Add a hostnetwork QoS
+  @NAMESPACE@.@NAME@.ovirt_qos:
+    auth: "{{ ovirt_auth }}"
+    name: "myqos"
+    data_center: "Default"
+    state: "present"
+    type: "cpu"
+    cpu_limit: 10
 '''
 
 RETURN = '''


### PR DESCRIPTION
Summary

- Adds ovirt_qos module to create a new QoS entry
- Adds ovirt_disk_profile to create a new disk profile
- Updates ovirt_disk to allow you to define the disk_profile on creation or to update a disk that currently exists

Examples
```yaml
  ovirt.ovirt.ovirt_qos:
    auth: "{{ ovirt_auth }}"
    name: "myqos"
    data_center: "Default"
    state: "present"
    max_iops: "100"
    max_throughput: "100"
    type: "storage"

  ovirt.ovirt.ovirt_disk_profile:
    auth: "{{ ovirt_auth }}"
    name: "mydisk"
    data_center: "Default"
    state: "present"
    storage_domain: "mystoragedomain"
    qos: "myqos"

  ovirt.ovirt.ovirt_disk:
    auth: "{{ ovirt_auth }}"
    name: "mydisk"
    profile: "myqos"
    state: "present"

```