### PR TITLE
roles: hosted_engine_setup: Support disa stig profile

### DIFF
--- a/changelogs/fragments/426-ovirt_hosted-engine_setup-support-disa-stig-profile.yml
+++ b/changelogs/fragments/426-ovirt_hosted-engine_setup-support-disa-stig-profile.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Support disa stig profile (https://github.com/oVirt/ovirt-ansible-collection/pull/426).

--- a/roles/hosted_engine_setup/files/35-allow-ansible-for-vdsm.rules
+++ b/roles/hosted_engine_setup/files/35-allow-ansible-for-vdsm.rules
@@ -1,0 +1,4 @@
+# Added by hosted-engine-setup for running Ansible's commands as vdsm user
+# For more details see https://bugzilla.redhat.com/1903549
+
+allow perm=any uid=36 : dir=/var/tmp/

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -149,25 +149,29 @@
     with_items:
       - {src: "{{ he_local_vm_dir }}/vm.conf", dest: /var/run/ovirt-hosted-engine-ha}
       - {src: "{{ he_local_vm_dir }}/hosted-engine.conf", dest: /etc/ovirt-hosted-engine/}
-  - name: Verify fapolicyd.rules file
-    stat:
-      path: /etc/fapolicyd/fapolicyd.rules
-    register: fapolicy_rules
-  - name: Add rule to fapolicyd.rules file
-    blockinfile:
-      path: /etc/fapolicyd/fapolicyd.rules
-      block: |
-        # temporary entry added by hosted-engine-setup for running commands as vdsm user
-        allow perm=any uid=36 : dir=/var/tmp/
-      insertbefore: "^# Allow any program to open trusted language files"
-      marker: "## {mark} HOSTED-ENGINE-SETUP MANAGED BLOCK ##"
-      backup: yes
-    when: fapolicy_rules.stat.exists
-  - name: Restart fapolicyd service
-    service:
+  - name: Check fapolicyd status
+    systemd:
       name: fapolicyd
-      state: restarted
-    when: fapolicy_rules.stat.exists
+    register: fapolicyd_s
+  - name: Set fapolicyd rules path
+    set_fact:
+      fapolicyd_rules_dir: /etc/fapolicyd/rules.d
+  - name: Verify fapolicyd/rules.d directory
+    stat:
+      path: "{{ fapolicyd_rules_dir }}"
+    register: fapolicy_rules
+  - name: Add rule to fapolicy
+    block:
+      - name: Add rule to /etc/fapolicyd/rules.d
+        copy:
+          src: 35-allow-ansible-for-vdsm.rules
+          dest: "{{ fapolicyd_rules_dir }}"
+          mode: 0644
+      - name: Restart fapolicyd service
+        service:
+          name: fapolicyd
+          state: restarted
+    when: fapolicyd_s.status.SubState == 'running' and fapolicy_rules.stat.exists
   - name: Copy configuration archive to storage
     command: >-
       dd bs=20480 count=1 oflag=direct if="{{ he_local_vm_dir }}/{{ he_conf_disk_details.disk.image_id }}"
@@ -274,18 +278,17 @@
     become_method: sudo
     changed_when: true
     when: he_debug_mode|bool
-    # TODO: Check if this rule exists and remove it on cleanup
-  - name: Remove a temporary rule in fapolicyd.rules file
-    blockinfile:
-      path: /etc/fapolicyd/fapolicyd.rules
-      marker: "## {mark} HOSTED-ENGINE-SETUP MANAGED BLOCK ##"
-      state: absent
-    when: fapolicy_rules.stat.exists
-  - name: Restart fapolicyd service
-    service:
-      name: fapolicyd
-      state: restarted
-    when: fapolicy_rules.stat.exists
+  - name: Remove rule from fapolicy
+    block:
+      - name: Remove rule from /etc/fapolicyd/rules.d
+        file:
+          path: "{{ fapolicyd_rules_dir }}/35-allow-ansible-for-vdsm.rules"
+          state: absent
+      - name: Restart fapolicyd service
+        service:
+          name: fapolicyd
+          state: restarted
+    when: fapolicyd_s.status.SubState == 'running' and fapolicy_rules.stat.exists
   - name: Remove temporary entry in /etc/hosts for the local VM
     lineinfile:
       dest: /etc/hosts

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -162,8 +162,6 @@
     command: dd bs=1M count=1024 oflag=direct if=/dev/zero of="{{ he_metadata_disk_path }}"
     environment: "{{ he_cmd_lang }}"
     become: true
-    become_user: vdsm
-    become_method: sudo
     changed_when: true
   - include_tasks: ../get_local_vm_disk_path.yml
   - name: Generate DHCP network configuration for the engine VM
@@ -242,15 +240,11 @@
       qemu-img convert -f qcow2 -O raw -t none -T none {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
     environment: "{{ he_cmd_lang }}"
     become: true
-    become_user: vdsm
-    become_method: sudo
     changed_when: true
   - name: Verify copy of VM disk
     command: qemu-img compare {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
     environment: "{{ he_cmd_lang }}"
     become: true
-    become_user: vdsm
-    become_method: sudo
     changed_when: true
     when: he_debug_mode|bool
   - name: Remove temporary entry in /etc/hosts for the local VM

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -149,12 +149,33 @@
     with_items:
       - {src: "{{ he_local_vm_dir }}/vm.conf", dest: /var/run/ovirt-hosted-engine-ha}
       - {src: "{{ he_local_vm_dir }}/hosted-engine.conf", dest: /etc/ovirt-hosted-engine/}
+  - name: Verify fapolicyd.rules file
+    stat:
+      path: /etc/fapolicyd/fapolicyd.rules
+    register: fapolicy_rules
+  - name: Add rule to fapolicyd.rules file
+    blockinfile:
+      path: /etc/fapolicyd/fapolicyd.rules
+      block: |
+        # temporary entry added by hosted-engine-setup for running commands as vdsm user
+        allow perm=any uid=36 : dir=/var/tmp/
+      insertbefore: "^# Allow any program to open trusted language files"
+      marker: "## {mark} HOSTED-ENGINE-SETUP MANAGED BLOCK ##"
+      backup: yes
+    when: fapolicy_rules.stat.exists
+  - name: Restart fapolicyd service
+    service:
+      name: fapolicyd
+      state: restarted
+    when: fapolicy_rules.stat.exists
   - name: Copy configuration archive to storage
     command: >-
       dd bs=20480 count=1 oflag=direct if="{{ he_local_vm_dir }}/{{ he_conf_disk_details.disk.image_id }}"
       of="{{ he_conf_disk_path }}"
     environment: "{{ he_cmd_lang }}"
     become: true
+    become_user: vdsm
+    become_method: sudo
     changed_when: true
     args:
       warn: false
@@ -162,6 +183,8 @@
     command: dd bs=1M count=1024 oflag=direct if=/dev/zero of="{{ he_metadata_disk_path }}"
     environment: "{{ he_cmd_lang }}"
     become: true
+    become_user: vdsm
+    become_method: sudo
     changed_when: true
   - include_tasks: ../get_local_vm_disk_path.yml
   - name: Generate DHCP network configuration for the engine VM
@@ -240,13 +263,29 @@
       qemu-img convert -f qcow2 -O raw -t none -T none {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
     environment: "{{ he_cmd_lang }}"
     become: true
+    become_user: vdsm
+    become_method: sudo
     changed_when: true
   - name: Verify copy of VM disk
     command: qemu-img compare {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
     environment: "{{ he_cmd_lang }}"
     become: true
+    become_user: vdsm
+    become_method: sudo
     changed_when: true
     when: he_debug_mode|bool
+    # TODO: Check if this rule exists and remove it on cleanup
+  - name: Remove a temporary rule in fapolicyd.rules file
+    blockinfile:
+      path: /etc/fapolicyd/fapolicyd.rules
+      marker: "## {mark} HOSTED-ENGINE-SETUP MANAGED BLOCK ##"
+      state: absent
+    when: fapolicy_rules.stat.exists
+  - name: Restart fapolicyd service
+    service:
+      name: fapolicyd
+      state: restarted
+    when: fapolicy_rules.stat.exists
   - name: Remove temporary entry in /etc/hosts for the local VM
     lineinfile:
       dest: /etc/hosts


### PR DESCRIPTION
DISA STIG profile uses fapolicyd that blocks ansible command execution as non-root
(see: https://bugzilla.redhat.com/show_bug.cgi?id=1903549)
Adding a rule to /etc/fapolicyd/rules.d to allow ansible command execution as `vdsm` user.
The rule will be removed once it's no longer required.

Bug-Url: https://bugzilla.redhat.com/2020620
Signed-off-by: Asaf Rachmani <arachman@redhat.com>