### PR TITLE
repositories: fix force flag on subscription-manager

### DIFF
--- a/changelogs/fragments/430-repositories-fix-force-flag-on-subscription-manager.yml
+++ b/changelogs/fragments/430-repositories-fix-force-flag-on-subscription-manager.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - repositories - fix force flag on subscription-manager (https://github.com/oVirt/ovirt-ansible-collection/pull/430).

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -23,7 +23,7 @@
     subscription-manager register
     --username {{ ovirt_repositories_rh_username }}
     --password {{ ovirt_repositories_rh_password }}
-    {% if ovirt_repositories_force_register is defined %} --force {% endif %}
+    {% if ovirt_repositories_force_register is defined and ovirt_repositories_force_register|bool %} --force {% endif %}
     {% if ovirt_repositories_rhsm_server_hostname is defined %} --serverurl {{ ovirt_repositories_rhsm_server_hostname }} {% endif %}
   changed_when: false
   no_log: true


### PR DESCRIPTION
Issue: The force flag on subscription-manager was always present. It was just checking if the  `ovirt_repositories_force_register` was defined which was in default so it was always present.