### PR TITLE
Add delay after patching the current host

### DIFF
--- a/roles/cluster_upgrade/README.md
+++ b/roles/cluster_upgrade/README.md
@@ -20,6 +20,7 @@ Role Variables
 | healing_in_progress_checks            | 6                     | Maximum number of attempts to check if gluster healing is still in progress. |
 | healing_in_progress_check_delay              | 300                   | The delay in seconds between each attempt to check if gluster healing is still in progress.    |
 | wait_to_finish_healing  | 5                     | Delay in minutes to wait to finish gluster healing process after successful host upgrade.             |
+| wait_before_next_upgrade| 5                     | Delay in minutes to wait for the currrent patched host to get to a good state, before continuing with the next    |
 | engine_correlation_id  | UNDEF                  | The correlation id with which be the role run.             |
 
 Example Playbook

--- a/roles/cluster_upgrade/defaults/main.yml
+++ b/roles/cluster_upgrade/defaults/main.yml
@@ -14,3 +14,4 @@ pinned_vms_names: []
 healing_in_progress_checks: 6
 healing_in_progress_check_delay: 300
 wait_to_finish_healing: 5
+wait_before_next_upgrade: 5

--- a/roles/cluster_upgrade/tasks/upgrade.yml
+++ b/roles/cluster_upgrade/tasks/upgrade.yml
@@ -133,6 +133,12 @@
       - cluster_info.ovirt_clusters[0].gluster_service | bool
       - host_info.ovirt_hosts | length > 1
 
+  - name: Delay in minutes to wait to upgraded host getting good state
+    pause:
+      minutes: "{{ wait_before_next_upgrade }}"
+    when:
+      - host_info.ovirt_hosts | length > 1
+
   - name: progress - host upgrade complete (host 100% complete)
     include_tasks: log_progress.yml
     vars:


### PR DESCRIPTION
Add delay after patching the current host, before continuing with the next host

After patching a host, it takes some time before that host (after rebooting) is a valid target again for guests to be migrated to.
With a 2 node cluster, this can cause the patching of the second host to fail because the guests cannot be migrated of that host or to cause the guests to be shutdown (depending on the used parameters).
This can be avoided by adding a delay (controlled by the wait_before_next_upgrade parameter, defaulting to 5 minutes) before continuing with the next host