### PR TITLE
roles: hosted_engine_setup: Use cat command instead of lookup

### DIFF
--- a/changelogs/fragments/443-ovirt_hosted_engine_setup-use-cat-command.yml
+++ b/changelogs/fragments/443-ovirt_hosted_engine_setup-use-cat-command.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Use cat command (https://github.com/oVirt/ovirt-ansible-collection/pull/443).

--- a/roles/hosted_engine_setup/tasks/create_storage_domain.yml
+++ b/roles/hosted_engine_setup/tasks/create_storage_domain.yml
@@ -124,11 +124,11 @@
       use_regex: true
     register: app_ovf
   - name: Get ovf data
-    set_fact:
-      ovf_data: "{{ lookup('file', app_ovf.files[0].path) }}"
+    command: cat "{{ app_ovf.files[0].path }}"
+    register: ovf_data
   - name: Get disk size from ovf data
     set_fact:
-      disk_size: "{{ ovf_data | @NAMESPACE@.@NAME@.get_ovf_disk_size }}"
+      disk_size: "{{ ovf_data['stdout'] | @NAMESPACE@.@NAME@.get_ovf_disk_size }}"
   - name: Get required size
     set_fact:
       required_size: >-


### PR DESCRIPTION
We get "could not locate file in lookup:" error, probably because
lookups execute and are evaluated on the Ansible control machine
and not on the remote machine

Signed-off-by: Asaf Rachmani <arachman@redhat.com>