### PR TITLE
Automation: Fix ansible build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,9 @@ jobs:
       image: quay.io/centos/centos:stream8
     steps:
       - name: Install packages
-        run: yum install -y createrepo_c rpm-build yum-utils git epel-release
+        run: yum install -y createrepo_c rpm-build yum-utils git
       - name: Install ansible packages
-        run: yum install -y ansible ansible-test python3-pycodestyle python3-pylint python3-voluptuous yamllint glibc-langpack-en
+        run: yum install -y ansible-core ansible-test python3-pycodestyle python3-pylint python3-voluptuous yamllint glibc-langpack-en
       - name: Update all packages
         run: yum update -y
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,9 +17,12 @@ jobs:
       - name: Install packages
         run: yum install -y createrepo_c rpm-build yum-utils git
       - name: Install ansible packages
-        run: yum install -y ansible-core ansible-test python3-pycodestyle python3-pylint python3-voluptuous yamllint glibc-langpack-en
+        run: yum install -y ansible-core ansible-test glibc-langpack-en
       - name: Update all packages
         run: yum update -y
+
+      - name: Install pip modules
+        run: pip3 install pycodestyle pylint==2.4.4 voluptuous yamllint
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The ansible-core is provided by default repos from el8stream we don't need to use epel.