### PR TITLE
cluster_upgrade: Directly log progress to the cluster

### DIFF
--- a/changelogs/fragments/449-cluster_upgrade-progress-log.yml
+++ b/changelogs/fragments/449-cluster_upgrade-progress-log.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cluster_upgrade - Directly log progress to the cluster (https://github.com/oVirt/ovirt-ansible-collection/pull/449)

--- a/roles/cluster_upgrade/tasks/log_progress.yml
+++ b/roles/cluster_upgrade/tasks/log_progress.yml
@@ -21,3 +21,18 @@
       origin: "cluster_upgrade"
       description: "{{ message | join('') }}"
       cluster: "{{ cluster_id | default(omit) }}"
+
+  - name: Update the upgrade progress on the cluster
+    no_log: false
+    uri:
+      url: "{{ ovirt_auth.url }}/clusters/{{ cluster_id }}/upgrade"
+      method: POST
+      body_format: json
+      validate_certs: false
+      headers:
+        Authorization: "Bearer {{ ovirt_auth.token }}"
+        Correlation-Id: "{{ engine_correlation_id | default(omit) }}"
+      body:
+        upgrade_action: update
+        upgrade_percent_complete: "{{ progress }}"
+    when: api_gt45

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -47,6 +47,7 @@
     - name: Remember the api version and cluster id
       set_fact:
         api_gt43: "{{ api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 3 }}"
+        api_gt45: "{{ api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 5 }}"
         cluster_id: "{{ cluster_info.ovirt_clusters[0].id }}"
 
     - name: progress 2% - cluster upgrade is starting


### PR DESCRIPTION
When running against a ovirt 4.5 instance, use the new REST feature defined by [ovirt-engine-api-model PR 32](https://github.com/oVirt/ovirt-engine-api-model/pull/32) and [ovirt-engine PR 170](https://github.com/oVirt/ovirt-engine/pull/170) to report the progress by both logging events and pushing the progress to the cluster.

Bug-Url: https://bugzilla.redhat.com/2040474