### PR TITLE
roles: hosted_engine_setup: Allow postgres user in fapolicyd

### DIFF
--- a/changelogs/fragments/452-ovirt_hosted-engine_setup-allow-postgres-in-fapolicyd.yml
+++ b/changelogs/fragments/452-ovirt_hosted-engine_setup-allow-postgres-in-fapolicyd.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Allow postgres user in fapolicyd (https://github.com/oVirt/ovirt-ansible-collection/pull/452).

--- a/roles/hosted_engine_setup/files/35-allow-ansible-for-postgres.rules
+++ b/roles/hosted_engine_setup/files/35-allow-ansible-for-postgres.rules
@@ -1,0 +1,4 @@
+# Added by hosted-engine-setup for running Ansible's commands as postgres user
+# For more details see https://bugzilla.redhat.com/1903549
+
+allow perm=any uid=26 : dir=/var/tmp/

--- a/roles/hosted_engine_setup/tasks/apply_fapolicyd_rule.yml
+++ b/roles/hosted_engine_setup/tasks/apply_fapolicyd_rule.yml
@@ -1,0 +1,24 @@
+---
+- name: Check fapolicyd status
+  systemd:
+    name: fapolicyd
+  register: fapolicyd_s
+- name: Set fapolicyd rules path
+  set_fact:
+    fapolicyd_rules_dir: /etc/fapolicyd/rules.d
+- name: Verify fapolicyd/rules.d directory
+  stat:
+    path: "{{ fapolicyd_rules_dir }}"
+  register: fapolicy_rules
+- name: Add rule to fapolicy
+  block:
+    - name: Add rule to /etc/fapolicyd/rules.d
+      copy:
+        src: "{{ fapolicyd_rule_file }}"
+        dest: "{{ fapolicyd_rules_dir }}"
+        mode: 0644
+    - name: Restart fapolicyd service
+      service:
+        name: fapolicyd
+        state: restarted
+  when: fapolicyd_s.status.SubState == 'running' and fapolicy_rules.stat.exists

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -81,6 +81,10 @@
             when: he_fips_enabled.stdout != "1"
         when: he_enable_fips|bool
     when: he_apply_openscap_profile|bool or he_enable_fips|bool
+  - name: Set fapolicyd rule file
+    set_fact:
+      fapolicyd_rule_file: 35-allow-ansible-for-postgres.rules
+  - include_tasks: ../apply_fapolicyd_rule.yml
   - name: Include before engine-setup custom tasks files for the engine VM
     include_tasks: "{{ item }}"
     with_fileglob: "hooks/enginevm_before_engine_setup/*.yml"

--- a/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -50,6 +50,17 @@
     environment: "{{ he_cmd_lang }}"
     changed_when: true
     when: he_restore_from_file is defined and he_restore_from_file
+  - name: Remove rule from fapolicy
+    block:
+      - name: Remove rule from /etc/fapolicyd/rules.d
+        file:
+          path: "{{ fapolicyd_rules_dir }}/35-allow-ansible-for-postgres.rules"
+          state: absent
+      - name: Restart fapolicyd service
+        service:
+          name: fapolicyd
+          state: restarted
+    when: fapolicyd_s.status.SubState == 'running' and fapolicy_rules.stat.exists
   - name: Remove DisableFenceAtStartupInSec temporary file
     file:
       path: /root/DisableFenceAtStartupInSec.txt

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -149,29 +149,10 @@
     with_items:
       - {src: "{{ he_local_vm_dir }}/vm.conf", dest: /var/run/ovirt-hosted-engine-ha}
       - {src: "{{ he_local_vm_dir }}/hosted-engine.conf", dest: /etc/ovirt-hosted-engine/}
-  - name: Check fapolicyd status
-    systemd:
-      name: fapolicyd
-    register: fapolicyd_s
-  - name: Set fapolicyd rules path
+  - name: Set fapolicyd rule file
     set_fact:
-      fapolicyd_rules_dir: /etc/fapolicyd/rules.d
-  - name: Verify fapolicyd/rules.d directory
-    stat:
-      path: "{{ fapolicyd_rules_dir }}"
-    register: fapolicy_rules
-  - name: Add rule to fapolicy
-    block:
-      - name: Add rule to /etc/fapolicyd/rules.d
-        copy:
-          src: 35-allow-ansible-for-vdsm.rules
-          dest: "{{ fapolicyd_rules_dir }}"
-          mode: 0644
-      - name: Restart fapolicyd service
-        service:
-          name: fapolicyd
-          state: restarted
-    when: fapolicyd_s.status.SubState == 'running' and fapolicy_rules.stat.exists
+      fapolicyd_rule_file: 35-allow-ansible-for-vdsm.rules
+  - include_tasks: ../apply_fapolicyd_rule.yml
   - name: Copy configuration archive to storage
     command: >-
       dd bs=20480 count=1 oflag=direct if="{{ he_local_vm_dir }}/{{ he_conf_disk_details.disk.image_id }}"


### PR DESCRIPTION
DISA STIG profile uses fapolicyd that blocks ansible command execution as non-root
(see: https://bugzilla.redhat.com/show_bug.cgi?id=1903549)
Adding a rule to /etc/fapolicyd/rules.d to allow ansible command execution as postgres user.
The rule will be removed once it's no longer required.

Bug-Url: https://bugzilla.redhat.com/2066811
Signed-off-by: Asaf Rachmani <arachman@redhat.com>