### PR TITLE
Replace calls to psql as postgres with engine_psql.sh

### DIFF
--- a/changelogs/fragments/453-replace-calls-to-psql-as-postgres-with-engine_psql.yml
+++ b/changelogs/fragments/453-replace-calls-to-psql-as-postgres-with-engine_psql.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hosted_engine_setup - Replace calls to psql as postgres with engine_psql.sh (https://github.com/oVirt/ovirt-ansible-collection/pull/453).

--- a/roles/hosted_engine_setup/defaults/main.yml
+++ b/roles/hosted_engine_setup/defaults/main.yml
@@ -36,6 +36,8 @@ he_webui_forward_port: 6900  # by default already open for VM console
 he_reserved_memory_MB: 512
 he_avail_memory_grace_MB: 200
 
+engine_psql: /usr/share/ovirt-engine/dbscripts/engine-psql.sh
+
 he_host_ip: null
 he_host_name: null
 he_host_address: null

--- a/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -10,37 +10,28 @@
       mode: 0700
   - name: Update target VM details at DB level
     command: >-
-      psql -d engine -c
+      "{{ engine_psql }}" -c
       "UPDATE vm_static SET {{ item.field }}={{ item.value }} WHERE
       vm_guid='{{ hostvars[he_ansible_host_name]['he_vm_details']['vm']['id'] }}'"
     environment: "{{ he_cmd_lang }}"
-    become: true
-    become_user: postgres
-    become_method: sudo
     changed_when: true
     register: db_vm_update
     with_items:
       - {field: 'origin', value: 6}
   - name: Insert Hosted Engine configuration disk uuid into Engine database
     command: >-
-      psql -d engine -c
+      "{{ engine_psql }}" -c
       "UPDATE vdc_options SET option_value=
       '{{ hostvars[he_ansible_host_name]['he_conf_disk_details']['disk']['id'] }}'
       WHERE option_name='HostedEngineConfigurationImageGuid' AND version='general'"
     environment: "{{ he_cmd_lang }}"
-    become: true
-    become_user: postgres
-    become_method: sudo
     changed_when: true
     register: db_conf_update
   - name: Fetch host SPM_ID
     command: >-
-      psql -t -d engine -c
+      "{{ engine_psql }}" -c
       "SELECT vds_spm_id FROM vds WHERE vds_name='{{ hostvars[he_ansible_host_name]['he_host_name'] }}'"
     environment: "{{ he_cmd_lang }}"
-    become: true
-    become_user: postgres
-    become_method: sudo
     changed_when: true
     register: host_spm_id_out
   - name: Parse host SPM_ID

--- a/roles/hosted_engine_setup/tasks/restore_backup.yml
+++ b/roles/hosted_engine_setup/tasks/restore_backup.yml
@@ -41,59 +41,44 @@
     path: /root/engine_backup
 - name: Remove previous hosted-engine VM
   command: >-
-    psql -d engine -c "SELECT deletevm(vm_guid) FROM (SELECT vm_guid FROM vms WHERE origin=6) t"
+    "{{ engine_psql }}" -c "SELECT deletevm(vm_guid) FROM (SELECT vm_guid FROM vms WHERE origin=6) t"
   environment: "{{ he_cmd_lang }}"
-  become: true
-  become_user: postgres
-  become_method: sudo
   changed_when: true
   register: db_remove_old_enginevm
 - name: Update dynamic data for VMs on the host used to redeploy
   command: >-
-    psql -d engine -c
+    "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET run_on_vds = NULL, status=0 /* Down */ WHERE run_on_vds IN
     (SELECT vds_id FROM vds
     WHERE upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}'))"
   environment: "{{ he_cmd_lang }}"
-  become: true
-  become_user: postgres
-  become_method: sudo
   changed_when: true
   register: db_update_host_vms
 - name: Update dynamic data for VMs migrating to the host used to redeploy
   command: >-
-    psql -d engine -c
+    "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET migrating_to_vds = NULL, status=0 /* Down */ WHERE migrating_to_vds IN
     (SELECT vds_id FROM vds WHERE
     upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}'))"
   environment: "{{ he_cmd_lang }}"
-  become: true
-  become_user: postgres
-  become_method: sudo
   changed_when: true
   register: db_update_host_migrating_vms
 - name: Remove host used to redeploy
   command: >-
-    psql -d engine -c
+    "{{ engine_psql }}" -c
     "SELECT deletevds(vds_id) FROM
     (SELECT vds_id FROM vds WHERE
     upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}')) t"
   environment: "{{ he_cmd_lang }}"
-  become: true
-  become_user: postgres
-  become_method: sudo
   changed_when: true
   register: db_remove_he_host
 - name: Rename previous HE storage domain to avoid name conflicts
   command: >-
-    psql -d engine -c
+    "{{ engine_psql }}" -c
     "UPDATE storage_domain_static SET
     storage_name='{{ he_storage_domain_name }}_old_{{ ansible_date_time.iso8601_basic_short }}' WHERE
     storage_name='{{ he_storage_domain_name }}'"
   environment: "{{ he_cmd_lang }}"
-  become: true
-  become_user: postgres
-  become_method: sudo
   changed_when: true
   register: db_rename_he_sd
 - name: Save original DisableFenceAtStartupInSec


### PR DESCRIPTION
engine_psql.sh is a script provided by the engine to access its DB.
It does not su/sudo to postgres but uses the configured credentials.
Do this for FIPS support, where psql as postgres fails.