### PR TITLE
Repositories: fix dnf module variable

### DIFF
--- a/changelogs/fragments/454-repositories-fix-dnf-module-variable.yml
+++ b/changelogs/fragments/454-repositories-fix-dnf-module-variable.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - repositories - fix dnf module variable (https://github.com/oVirt/ovirt-ansible-collection/pull/454).

--- a/changelogs/fragments/454-repositories-fix-dnf-module-variable.yml
+++ b/changelogs/fragments/454-repositories-fix-dnf-module-variable.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - repositories - fix dnf module variable (https://github.com/oVirt/ovirt-ansible-collection/pull/454).
+  - repositories - Fix dnf module variable (https://github.com/oVirt/ovirt-ansible-collection/pull/454).

--- a/roles/repositories/tasks/satellite-subscription.yml
+++ b/roles/repositories/tasks/satellite-subscription.yml
@@ -21,7 +21,7 @@
   changed_when: false
 
 - name: Enable dnf modules
-  command: "dnf module enable -y {{ ovirt_repositories_dnf_modules | join(' ') }}"
+  command: "dnf module enable -y {{ ovirt_repositories_rh_dnf_modules | join(' ') }}"
   args:
     warn: False
   when:


### PR DESCRIPTION
Use the proper variable in repositories to set dnf modules when using satellite 