### PR TITLE
roles: hosted_engine_setup: Fix call to engine-psql for vds_spm_id

### DIFF
--- a/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -29,7 +29,7 @@
     register: db_conf_update
   - name: Fetch host SPM_ID
     command: >-
-      "{{ engine_psql }}" -c
+      "{{ engine_psql }}" -t -c
       "SELECT vds_spm_id FROM vds WHERE vds_name='{{ hostvars[he_ansible_host_name]['he_host_name'] }}'"
     environment: "{{ he_cmd_lang }}"
     changed_when: true


### PR DESCRIPTION
A recent patch replaced 'psql -d engine' with 'engine-psql'. One call
also passed '-t' (tuples-only), but that patch dropped this option, thus
breaking parsing of the output. Restore this option.