### PR TITLE
fix creating a RAW vm from a COW template

### DIFF
--- a/changelogs/fragments/466-ovirt_vm-fix-creating-raw-vm-from-cow-template.yml
+++ b/changelogs/fragments/466-ovirt_vm-fix-creating-raw-vm-from-cow-template.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_vm - Fix creating a RAW VM from a COW template  (https://github.com/oVirt/ovirt-ansible-collection/pull/466).

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -1449,6 +1449,7 @@ class VmsModule(BaseModule):
                     disk=otypes.Disk(
                         id=att.disk.id,
                         format=otypes.DiskFormat(self.param('disk_format')),
+                        sparse=self.param('disk_format') != 'raw',
                         storage_domains=[
                             otypes.StorageDomain(
                                 id=get_id_by_name(


### PR DESCRIPTION
On a FC storage domain, creating a RAW vm (disk_format: "raw") from a COW template with vm_infra role gives as result : "Cannot add VM. Disk configuration (RAW Sparse backup-None) is incompatible with the storage domain type." 
I could be wrong on diagnostic but this seems to be caused by the unset "sparse" option. This commit fix it on our infrastructure.