### PR TITLE
spec: add ovirt-imageio-python38-client requirement

### DIFF
--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -30,6 +30,7 @@ Requires:	ansible-collection-ansible-utils
 Requires:	qemu-img
 
 %if 0%{?rhel} < 9
+Requires:	ovirt-imageio-python38-client
 Requires:	python38-ovirt-engine-sdk4 >= 4.5.0
 Requires:	python38-netaddr
 Requires:	python38-jmespath

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -30,7 +30,7 @@ Requires:	ansible-collection-ansible-utils
 Requires:	qemu-img
 
 %if 0%{?rhel} < 9
-Requires:	ovirt-imageio-python38-client
+Requires:	python38-ovirt-imageio-client
 Requires:	python38-ovirt-engine-sdk4 >= 4.5.0
 Requires:	python38-netaddr
 Requires:	python38-jmespath


### PR DESCRIPTION
Because of ansible-core 2.12 uses python38 we need to rebuild the imageio client for python38.
Related to https://github.com/oVirt/ovirt-imageio/pull/57