### PR TITLE
cluster_upgrade: fix upgrade progress log_progress task

### DIFF
--- a/changelogs/fragments/474-cluster-update-log-progress-fix.yml
+++ b/changelogs/fragments/474-cluster-update-log-progress-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix progress logging via REST (https://github.com/oVirt/ovirt-ansible-collection/pull/474).

--- a/roles/cluster_upgrade/tasks/log_progress.yml
+++ b/roles/cluster_upgrade/tasks/log_progress.yml
@@ -33,6 +33,8 @@
         Authorization: "Bearer {{ ovirt_auth.token }}"
         Correlation-Id: "{{ engine_correlation_id | default(omit) }}"
       body:
-        upgrade_action: update
+        upgrade_action: update_progress
         upgrade_percent_complete: "{{ progress }}"
-    when: api_gt45
+    when:
+      - api_gt45 is defined and api_gt45
+      - upgrade_set is defined


### PR DESCRIPTION
Fixes: #476

Two critical fixes:

  - Due to REST api changes during the review cycles, the `upgrade_action`
    needed to change from `update` to `update_progress`

  - The "Update the upgrade progress on the cluster" task will only
    work once we know the API version, we know the version is at least
    ovirt 4.5 and the cluster upgrade action has been started.  Adjust
    its `when` clause to reflect those requirements.

For reference:
  - REST api for the cluster upgrade endpoint: http://ovirt.github.io/ovirt-engine-api-model/master/#services/cluster/methods/upgrade
  - Valid `update_action` values: http://ovirt.github.io/ovirt-engine-api-model/master/#services/cluster/methods/upgrade