### PR TITLE
Obsolete ansible 2.9

### DIFF
--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -17,7 +17,7 @@ BuildRequires:	ansible-test
 BuildRequires:	glibc-langpack-en
 %endif
 
-Requires:    ansible-core >= 2.12.0
+Requires:	ansible-core >= 2.12.0
 Requires:	ovirt-imageio-client
 Requires:	python3-ovirt-engine-sdk4 >= 4.5.0
 Requires:	python3-netaddr
@@ -36,6 +36,7 @@ Requires:	python38-jmespath
 Requires:	python38-passlib
 %endif
 
+Obsoletes:	ansible < 2.10.0
 Obsoletes:	ovirt-ansible-cluster-upgrade
 Obsoletes:	ovirt-ansible-disaster-recovery
 Obsoletes:	ovirt-ansible-engine-setup


### PR DESCRIPTION
Since ansible-core 2.12.3 the package does not obsolete but conflicts with ansible<2.10 and because of this, the upgrade fails.
The solution for this is to add our obsolete. When doing an upgrade from now it will remove the ansible 2.9 and install ansible-core 2.12.