### PR TITLE
automation: Use rstcheck < 3.5.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pip modules
         run: >
-          pip3 install pycodestyle pylint==2.4.4 voluptuous yamllint rstcheck antsibull-changelog "rich<11.0.0" "ansible-lint<5.0.0"
+          pip3 install pycodestyle pylint==2.4.4 voluptuous yamllint "rstcheck<3.5.0" antsibull-changelog "rich<11.0.0" "ansible-lint<5.0.0"
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/changelogs/fragments/490-use-rstcheck-3.4.yml
+++ b/changelogs/fragments/490-use-rstcheck-3.4.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - Use rstcheck < 3.5.0, as 3.5.0 emits a warning that fails testing. (https://github.com/oVirt/ovirt-ansible-collection/pull/490).


### PR DESCRIPTION
3.5.0 emits this to stderr:

   /usr/local/lib/python3.6/site-packages/rstcheck.py:51: FutureWarning:
   Python versions prior 3.7 are deprecated. Please update your python
   version.

TODO: Revert this once we upgrade to python 3.8 (or 3.9, or both) in
automation.