### PR TITLE
automation: Use cryptography < 37.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pip modules
         run: >
-          pip3 install pycodestyle pylint==2.4.4 voluptuous yamllint "rstcheck<3.5.0" antsibull-changelog "rich<11.0.0" "ansible-lint<5.0.0"
+          pip3 install pycodestyle pylint==2.4.4 voluptuous yamllint "rstcheck<3.5.0" antsibull-changelog "rich<11.0.0" "ansible-lint<5.0.0" 'cryptography<37.0.0'
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/changelogs/fragments/492-use-cryptography-older-than-37.yml
+++ b/changelogs/fragments/492-use-cryptography-older-than-37.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - Use cryptography < 37.0.0, as 37.0.0 emits a warning that fails testing. (https://github.com/oVirt/ovirt-ansible-collection/pull/492).


### PR DESCRIPTION
37.0.0 emits this to stderr:

   /tmp/ansible-test-_0gulbli/ansible/parsing/vault/__init__.py:44:
   CryptographyDeprecationWarning: Python 3.6 is no longer supported by
   the Python core team. Therefore, support for it is deprecated in
   cryptography and will be removed in a future release.

TODO: Revert this once we upgrade to python 3.8 (or 3.9, or both) in
automation.