### PR TITLE
roles: hosted_engine_setup: Require 'detail: Up'

### DIFF
--- a/changelogs/fragments/498-require-detail-up.yml
+++ b/changelogs/fragments/498-require-detail-up.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - hosted_engine_setup - Require 'detail' to be 'Up' (https://github.com/oVirt/ovirt-ansible-collection/pull/498).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -351,7 +351,8 @@
         register: health_result
         until: >-
           health_result.rc == 0 and 'health' in health_result.stdout and
-          health_result.stdout|from_json|@NAMESPACE@.@NAME@.json_query('*."engine-status"."health"')|first=="good"
+          health_result.stdout|from_json|@NAMESPACE@.@NAME@.json_query('*."engine-status"."health"')|first=="good" and
+          health_result.stdout|from_json|@NAMESPACE@.@NAME@.json_query('*."engine-status"."detail"')|first=="Up"
         retries: 180
         delay: 5
         changed_when: true


### PR DESCRIPTION
When checking, near the end of the deployment, if the engine is healthy,
do not only check that 'health' is 'good', but also that 'detail' is
'Up'.

We recently had a case in CI where due to some problem the engine took a
long time to start, timing out the monitoring in HA, causing it to stop
the VM, and 'detail' was 'Powering Down', but this went unnoticed,
causing things to fail much later. So, in such a case, fail early.