### PR TITLE
roles: hosted_engine_setup: fix archive ownership

### DIFF
--- a/changelogs/fragments/501-fix-archive-ownership.yml
+++ b/changelogs/fragments/501-fix-archive-ownership.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+     - hosted_engine_setup - fix archive ownership (https://github.com/oVirt/ovirt-ansible-collection/pull/501).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -133,6 +133,9 @@
     args:
       chdir: "{{ he_local_vm_dir }}"
       warn: false
+    become: true
+    become_user: vdsm
+    become_method: sudo
     changed_when: true
     tags: ['skip_ansible_lint']
   - name: Create ovirt-hosted-engine-ha run directory


### PR DESCRIPTION
with umask 0777 (default for DISA STIG) the archive is not readable
later when we try to copy it as vdsm user.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2089332
