### PR TITLE
Fix "'ansible' ModuleNotFoundError" in Disaster Recovery scripts

### DIFF
--- a/changelogs/fragments/503-fix-ansible-ModuleNotFoundError.yml
+++ b/changelogs/fragments/503-fix-ansible-ModuleNotFoundError.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Fix "'ansible' ModuleNotFoundError" in Disaster Recovery scripts (https://github.com/oVirt/ovirt-ansible-collection/pull/503).

--- a/roles/disaster_recovery/files/fail_back.py
+++ b/roles/disaster_recovery/files/fail_back.py
@@ -11,7 +11,6 @@ import sys
 import time
 
 from configparser import ConfigParser
-from ansible.module_utils.six.moves import input
 
 from bcolors import bcolors
 

--- a/roles/disaster_recovery/files/fail_over.py
+++ b/roles/disaster_recovery/files/fail_over.py
@@ -11,7 +11,6 @@ import sys
 import time
 
 from configparser import ConfigParser
-from ansible.module_utils.six.moves import input
 
 from bcolors import bcolors
 

--- a/roles/disaster_recovery/files/generate_vars.py
+++ b/roles/disaster_recovery/files/generate_vars.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 
 from configparser import ConfigParser
-from ansible.module_utils.six.moves import input
 
 import ovirtsdk4 as sdk
 

--- a/roles/disaster_recovery/files/ovirt-dr
+++ b/roles/disaster_recovery/files/ovirt-dr
@@ -10,7 +10,6 @@ import time
 import getopt
 
 from configparser import ConfigParser
-from six.moves import input
 
 import fail_back
 import fail_over

--- a/roles/disaster_recovery/files/validator.py
+++ b/roles/disaster_recovery/files/validator.py
@@ -12,7 +12,6 @@ from ovirtsdk4 import types
 
 from bcolors import bcolors
 from configparser import ConfigParser
-from ansible.module_utils.six.moves import input
 
 
 INFO = bcolors.OKGREEN


### PR DESCRIPTION
When executing any Disaster Recovery script, the following error is received:
```
[root@storage-ge-13 files]# ./ovirt-dr generate
Traceback (most recent call last):
  File "./ovirt-dr", line 15, in <module>
    import fail_back
  File "/usr/share/ansible/collections/ansible_collections/redhat/rhv/roles/disaster_recovery/files/fail_back.py", line 14, in <module>
    from ansible.module_utils.six.moves import input
ModuleNotFoundError: No module named 'ansible'
```

The reason for that is the following `import` statement: `from ansible.module_utils.six.moves import input`.

There is no need to use "`six`" library at all since Python2 is deprecated!
All "`import`"s of "`six`" module can be deleted now and the builtin Python3 "`input()`" function will be used instead.

Bug-Url: https://bugzilla.redhat.com/2090264