### PR TITLE
roles: hosted_engine_setup: final: Collect engine logs

### DIFF
--- a/changelogs/fragments/504-collect-final-logs.yml
+++ b/changelogs/fragments/504-collect-final-logs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Collect logs also on failures in 03_hosted_engine_final_tasks.yml (https://github.com/oVirt/ovirt-ansible-collection/pull/504).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -461,3 +461,13 @@
     include_tasks: "{{ item }}"
     with_fileglob: "hooks/after_setup/*.yml"
     register: after_setup_results
+  rescue:
+    - name: Fetch logs from the engine VM
+      include_tasks: ../fetch_engine_logs.yml
+      ignore_errors: true
+    - name: Notify the user about a failure
+      fail:
+        msg: >
+          The system may not be provisioned according to the playbook
+          results: please check the logs for the issue,
+          fix accordingly or re-deploy from scratch.


### PR DESCRIPTION
Collect logs also on failures in 03_hosted_engine_final_tasks.yml.

The logs are still only from the local VM's disk, not the target.

Pushing this patch because we had cases where 'Check OVF_STORE volume
status' timed out.