### PR TITLE
roles: hosted_engine_setup: Force updating the OVF store

### DIFF
--- a/changelogs/fragments/506-force-updating-ovf-store.yml
+++ b/changelogs/fragments/506-force-updating-ovf-store.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Force updating the ovf store (https://github.com/oVirt/ovirt-ansible-collection/pull/506).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -9,6 +9,13 @@
       description: "Hosted engine VM"
       serial_console: true
       auth: "{{ ovirt_auth }}"
+  - name: Force updating the OVF store
+    ovirt_storage_domain:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ he_storage_domain_name }}"
+      state: update_ovf_store
+    retries: 12
+    delay: 10
   - name: Wait until OVF update finishes
     ovirt_storage_domain_info:
       auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
Directly ask the engine to update the OVF store instead of just hoping
that it eventually does.

If this patch works, we might remove other code, such as
setting/restoring OvfUpdateIntervalInMinutes and related.

Related-To: https://bugzilla.redhat.com/2090638