### PR TITLE
roles: hosted_engine_setup: Fix keycloak activation/checking

### DIFF
--- a/changelogs/fragments/509-fix-keycloak-activation.yml
+++ b/changelogs/fragments/509-fix-keycloak-activation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - Fix keycloak activation/checking (https://github.com/oVirt/ovirt-ansible-collection/pull/509).

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -58,7 +58,7 @@
       path: /root/ovirt-engine-answers
       line: "{{ item }}"
     with_items:
-      - "OVESETUP_KEYCLOAK_CORE/enable=bool:{{ he_enable_keycloak }}"
+      - "OVESETUP_CONFIG/keycloakEnable=bool:{{ he_enable_keycloak }}"
   - name: Enable security policy
     block:
       - import_tasks: ../get_appliance_dist.yml

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
@@ -49,7 +49,7 @@
       - cloud-init-local
       - cloud-init
   - name: Check if keycloak is configured
-    command: otopi-config-query query -k OVESETUP_KEYCLOAK_CORE/enable -f /etc/ovirt-engine-setup.conf
+    command: otopi-config-query query -k OVESETUP_CONFIG/keycloakEnable -f /etc/ovirt-engine-setup.conf
     register: keycloak_configured_out
     ignore_errors: true
   - name: Set admin username


### PR DESCRIPTION
keycloak integration had two env keys for this, and recently unified
them. We used the one that was removed. So fix, to use the current one.