### PR TITLE
Revert "roles: hosted_engine_setup: Force updating the OVF store"

### DIFF
--- a/changelogs/fragments/506-force-updating-ovf-store.yml
+++ b/changelogs/fragments/506-force-updating-ovf-store.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - hosted_engine_setup - Force updating the ovf store (https://github.com/oVirt/ovirt-ansible-collection/pull/506).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -9,13 +9,6 @@
       description: "Hosted engine VM"
       serial_console: true
       auth: "{{ ovirt_auth }}"
-  - name: Force updating the OVF store
-    ovirt_storage_domain:
-      auth: "{{ ovirt_auth }}"
-      name: "{{ he_storage_domain_name }}"
-      state: update_ovf_store
-    retries: 12
-    delay: 10
   - name: Wait until OVF update finishes
     ovirt_storage_domain_info:
       auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
Reverts oVirt/ovirt-ansible-collection#506

it seems to be flaky, unfortunately. OST sometimes fails with
11:11:55 E [ INFO ] TASK [ovirt.ovirt.hosted_engine_setup : Force updating the OVF store]

11:11:55 E [ ERROR ] ovirtsdk4.Error: Fault reason is "Operation Failed". Fault detail is "[Cannot ${action} Storage. Storage Domain OVF data is currently being updated.]". HTTP response code is 409.

11:11:55 E [ ERROR ] fatal: [localhost]: FAILED! => {"changed": false, "msg": "Fault reason is "Operation Failed". Fault detail is "[Cannot ${action} Storage. Storage Domain OVF data is currently being updated.]". HTTP response code is 409."}