### PR TITLE
ovirt_storage_domain: Fix error for inaccessible storage domain

### DIFF
--- a/changelogs/fragments/534-ovirt_storage_domain-fix-inaccessible-error.yml
+++ b/changelogs/fragments/534-ovirt_storage_domain-fix-inaccessible-error.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_storage_domain - Fix inaccessible exception (https://github.com/oVirt/ovirt-ansible-collection/pull/534).

--- a/plugins/modules/ovirt_storage_domain.py
+++ b/plugins/modules/ovirt_storage_domain.py
@@ -708,6 +708,9 @@ def control_state(sd_module):
         sd_service = sd_module._attached_sd_service(sd)
         sd = get_entity(sd_service)
 
+    if sd is None:
+        return
+
     if sd.status == sdstate.LOCKED:
         wait(
             service=sd_service,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2084235

Now when running playbook like:
```yml
# Add data NFS storage domain
    - ovirt.ovirt.ovirt_storage_domain:
        name: Ble        #This name is used in the different data center
        host: host_mixed_2
        data_center: golden_env_mixed
        nfs:
          address: "{{nfs_server}}"
          path: "{{nfs_path}}"
        auth: "{{ovirt_auth}}"
```

It will throw exception from engine:
```
    "msg": "Fault reason is \"Operation Failed\". Fault detail is \"[Cannot attach Storage. The relevant Storage Domain is inaccessible.\n-Please handle Storage Domain issues and retry the operation.]\". HTTP response code is 409."
```