### PR TITLE
CI: ansible-lint add experimental to skip list

### DIFF
--- a/automation/build.sh
+++ b/automation/build.sh
@@ -68,7 +68,7 @@ cd "$COLLECTION_DIR"
 
 ansible-test sanity
 antsibull-changelog lint -v
-ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/shutdown_env --exclude roles/disaster_recovery --exclude roles/remove_stale_lun
+ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/shutdown_env --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
 
 cd "$ROOT_PATH"
 


### PR DESCRIPTION
After https://github.com/oVirt/ovirt-ansible-collection/pull/280 we are using the latest ansible-lint which does have not yet finished lints, those lint are labeled as experimental. I have decided to remove these lints from our CI.