### PR TITLE
ovirt_vm: check if user inputed graphical protocol

### DIFF
--- a/changelogs/fragments/542-ovirt_vm-check-graphical-protocol.yml
+++ b/changelogs/fragments/542-ovirt_vm-check-graphical-protocol.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_vm - check if user inputed graphical protocol (https://github.com/oVirt/ovirt-ansible-collection/pull/542).

--- a/plugins/modules/ovirt_vm.py
+++ b/plugins/modules/ovirt_vm.py
@@ -2044,7 +2044,7 @@ class VmsModule(BaseModule):
             return True
 
         # Update consoles:
-        if sorted(protocol) != sorted(current_protocols):
+        if protocol is not None and sorted(protocol) != sorted(current_protocols):
             if not self._module.check_mode:
                 for gc in graphical_consoles:
                     gcs_service.console_service(gc.id).remove()


### PR DESCRIPTION
Before this user needed to input the protocol when wanted to change any console params
but without protocol, it throws exception `    "msg": "'NoneType' object is not iterable"`