### PR TITLE
Fix 'ansible-lint' violations for 'disaster_recovery' & 'remove_stale_lun' roles

### DIFF
--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint -x unnamed-task,fqcn-builtins,no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint -x ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x var-spacing,unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint -x unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x unnamed-task,fqcn-builtins,no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint -x fqcn-builtins,no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -68,8 +68,7 @@ cd "$COLLECTION_DIR"
 
 ansible-test sanity
 antsibull-changelog lint -v
-ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint roles/* --exclude roles/hosted_engine_setup -x experimental
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x var-spacing,unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery
+ansible-lint -x var-spacing,unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -69,7 +69,7 @@ cd "$COLLECTION_DIR"
 ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
-ansible-lint -x fqcn-builtins,no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
+ansible-lint -x no-changed-when,ignore-errors roles/disaster_recovery roles/remove_stale_lun
 
 cd "$ROOT_PATH"
 

--- a/changelogs/fragments/554-fix-ansible_lint-for-disaster_recovery-and-remove_stale_lun.yml
+++ b/changelogs/fragments/554-fix-ansible_lint-for-disaster_recovery-and-remove_stale_lun.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix "ansible-lint" version 6.0.0 violations for "disaster_recovery" & "remove_stale_lun" roles (https://github.com/oVirt/ovirt-ansible-collection/pull/554).

--- a/roles/disaster_recovery/tasks/clean/remove_disks.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_disks.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Remove disk
+---
+- name: Remove disk main block
+  block:
+    - name: "Remove disk '{{ disk.id }}'"
       ovirt_disk:
         state: absent
         id: "{{ disk.id }}"

--- a/roles/disaster_recovery/tasks/clean/remove_domain.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_domain.yml
@@ -1,7 +1,9 @@
-- block:
+---
+- name: Remove storage domain main block
+  block:
     # If we get the exception "Cannot deactivate Master Data Domain while there are running tasks on its Data Center."
     # We should wait for some time and try again
-    - name: Remove storage domain
+    - name: "Remove storage domain '{{ sd.name }}'"
       ovirt_storage_domain:
         state: absent
         id: "{{ sd.id }}"

--- a/roles/disaster_recovery/tasks/clean/remove_domain_process.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_domain_process.yml
@@ -8,10 +8,10 @@
     # We set an initial value for sp_uuid since this task is being called
     # multiple times from the main task and sp_uuid is stateful.
     - name: Set default boolean value for sp_uuid
-      set_fact: sp_uuid=True
+      ansible.builtin.set_fact: sp_uuid=True
 
     - name: Detached storage domain - Set sp_uuid with empty GUID
-      set_fact: sp_uuid="00000000-0000-0000-0000-000000000000"
+      ansible.builtin.set_fact: sp_uuid="00000000-0000-0000-0000-000000000000"
       when: sd.data_centers is not defined
 
     - name: Detached storage domain - Fetch active host for remove
@@ -31,7 +31,7 @@
     # If sp_uuid is still initiated with the default boolean value,
     # that means that there is a data center which the storage domain is attached to it.
     - name: Attached storage domain - Set sp_uuid
-      set_fact: sp_uuid="{{ sd.data_centers[0].id }}"
+      ansible.builtin.set_fact: sp_uuid="{{ sd.data_centers[0].id }}"
       when: sp_uuid
 
     - name: Remove storage domain with no force

--- a/roles/disaster_recovery/tasks/clean/remove_domain_process.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_domain_process.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Remove storage domain process main block
+  block:
     # TODO: Check what happens when we force remove unattached storage domain (probably should add a default empty GUID as a data center
     # Answer: When we force remove an unattached storage domain, ansible tries to move it to maintenance and detach it first,
     # although it might be that this storage domain is already detached and has no related data center, therefor the move to maintenance will fail

--- a/roles/disaster_recovery/tasks/clean/remove_invalid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_invalid_filtered_master_domains.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Remove invalid storage domain main block
+  block:
     - name: Fetch invalid storage domain for remove
       ovirt_storage_domain_info:
         pattern: name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_inactive_domain_search }}

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Remove valid storage domain main block
+  block:
     - name: Fetch active/maintenance/detached storage domain for remove
       ovirt_storage_domain_info:
         pattern: >

--- a/roles/disaster_recovery/tasks/clean/remove_vms.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_vms.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Remove diskless VMs
+---
+- name: Remove diskless VM main block
+  block:
+    - name: "Remove diskless VM '{{ vm.name }}'"
       ovirt_vm:
         state: absent
         name: "{{ vm.name }}"

--- a/roles/disaster_recovery/tasks/clean/shutdown_vm.yml
+++ b/roles/disaster_recovery/tasks/clean/shutdown_vm.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Shutdown VM
+---
+- name: Shutdown VM main block
+  block:
+    - name: "Shutdown VM '{{ vms.name }}'"
       ovirt_vm:
         state: stopped
         name: "{{ vms.name }}"

--- a/roles/disaster_recovery/tasks/clean/shutdown_vms.yml
+++ b/roles/disaster_recovery/tasks/clean/shutdown_vms.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Shutdown VMs main block
+  block:
     # Get all the running VMs related to a storage domain and shut them down
     - name: Fetch VMs in the storage domain
       ovirt_vm_info:

--- a/roles/disaster_recovery/tasks/clean/update_ovf_store.yml
+++ b/roles/disaster_recovery/tasks/clean/update_ovf_store.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Update OVF store for active storage domain main block
+  block:
     - name: Fetch storage domain only if active
       ovirt_storage_domain_info:
         pattern: status = active and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}

--- a/roles/disaster_recovery/tasks/clean_engine.yml
+++ b/roles/disaster_recovery/tasks/clean_engine.yml
@@ -23,19 +23,19 @@
         loop_var: storage
 
     - name: Set force remove flag to false for non master domains
-      set_fact: dr_force=False
+      ansible.builtin.set_fact: dr_force=False
 
     # Set all the queries suffix to fetch a storage domain in a specific status.
     # Note: Export storage domain is not supported and should not be part of storage mapping
     - name: Setup queries for storage domains
-      set_fact:
+      ansible.builtin.set_fact:
         dr_active_domain_search='status = active and type != cinder'
         dr_maintenance_domain_search='status = maintenance and type != cinder'
         dr_unattached_domain_search='status = unattached and type != cinder and type != glance'
         dr_inactive_domain_search='type != glance and type != cinder and status != active'
 
     - name: Set master storage domain filter
-      set_fact: only_master=False
+      ansible.builtin.set_fact: only_master=False
 
     - name: Remove non master storage domains with valid statuses
       include_tasks: clean/remove_valid_filtered_master_domains.yml
@@ -47,7 +47,7 @@
     # We use inactive filter only at the end, since we are not sure if there were any storage domains
     # which became inactive on the process or if there were any at the beginning.
     - name: Set force remove flag to true for non master storage domains
-      set_fact: dr_force=True
+      ansible.builtin.set_fact: dr_force=True
 
     - name: Remove non master storage domains with invalid statuses using force remove
       include_tasks: clean/remove_invalid_filtered_master_domains.yml
@@ -57,10 +57,10 @@
         loop_var: storage
 
     - name: Set master storage domain filter
-      set_fact: only_master=True
+      ansible.builtin.set_fact: only_master=True
 
     - name: Set force remove flag to false for master domain
-      set_fact: dr_force=False
+      ansible.builtin.set_fact: dr_force=False
 
     - name: Remove master storage domains with valid statuses
       include_tasks: clean/remove_valid_filtered_master_domains.yml
@@ -70,7 +70,7 @@
         loop_var: storage
 
     - name: Set force remove flag to true for master domain
-      set_fact: dr_force=True
+      ansible.builtin.set_fact: dr_force=True
 
     - name: Remove master storage domains with invalid statuses using force remove
       include_tasks: clean/remove_invalid_filtered_master_domains.yml

--- a/roles/disaster_recovery/tasks/clean_engine.yml
+++ b/roles/disaster_recovery/tasks/clean_engine.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Clean engine main block
+  block:
     - name: Obtain SSO token
       ovirt_auth:
         url: "{{ vars['dr_sites_' + dr_source_map + '_url'] }}"
@@ -44,7 +46,7 @@
 
     # We use inactive filter only at the end, since we are not sure if there were any storage domains
     # which became inactive on the process or if there were any at the beginning.
-    - name: Set force remove flag to true for non master domains
+    - name: Set force remove flag to true for non master storage domains
       set_fact: dr_force=True
 
     - name: Remove non master storage domains with invalid statuses using force remove
@@ -92,7 +94,7 @@
       register: vm_info
       when: dr_clean_orphaned_vms and storage_domain_info.ovirt_storage_domains | length == 0
 
-    - name: Remove vms if no storage domains left in setup
+    - name: Remove VMs if no storage domains left in setup
       include_tasks: clean/remove_vms.yml
       vars:
         vm: "{{ item }}"

--- a/roles/disaster_recovery/tasks/generate_mapping.yml
+++ b/roles/disaster_recovery/tasks/generate_mapping.yml
@@ -9,6 +9,7 @@
         -p "{{ password }}"
         -c "{{ ca }}"
         -f "{{ var_file }}"
+      changed_when: true
       run_once: true
   tags:
     - generate_mapping

--- a/roles/disaster_recovery/tasks/generate_mapping.yml
+++ b/roles/disaster_recovery/tasks/generate_mapping.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Generate mapping var file main block
+  block:
     - name: Generate mapping var file
       command: python3 {{ role_path }}/files/generate_mapping.py -a "{{ site }}" -u "{{ username }}" -p "{{ password }}" -c "{{ ca }}" -f "{{ var_file }}"
       run_once: true

--- a/roles/disaster_recovery/tasks/generate_mapping.yml
+++ b/roles/disaster_recovery/tasks/generate_mapping.yml
@@ -2,7 +2,13 @@
 - name: Generate mapping var file main block
   block:
     - name: Generate mapping var file
-      command: python3 {{ role_path }}/files/generate_mapping.py -a "{{ site }}" -u "{{ username }}" -p "{{ password }}" -c "{{ ca }}" -f "{{ var_file }}"
+      ansible.builtin.command: >-
+        python3 {{ role_path }}/files/generate_mapping.py
+        -a "{{ site }}"
+        -u "{{ username }}"
+        -p "{{ password }}"
+        -c "{{ ca }}"
+        -f "{{ var_file }}"
       run_once: true
   tags:
     - generate_mapping

--- a/roles/disaster_recovery/tasks/main.yml
+++ b/roles/disaster_recovery/tasks/main.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Main block
+  block:
     - name: Start to unregister entities
       include_tasks: unregister_entities.yml
       tags:
@@ -27,7 +29,7 @@
       tags:
         - fail_back
 
-    - name: Genereate mapping var file
+    - name: Generate mapping var file
       include_tasks: generate_mapping.yml
       tags:
         - generate_mapping

--- a/roles/disaster_recovery/tasks/main.yml
+++ b/roles/disaster_recovery/tasks/main.yml
@@ -13,7 +13,7 @@
         - clean_engine
 
     - name: Failback Replication Sync pause
-      pause:
+      ansible.builtin.pause:
         prompt: "[Failback Replication Sync] Please press ENTER once the destination storage domains are ready to be used for the destination setup"
       tags:
         - fail_back

--- a/roles/disaster_recovery/tasks/recover/add_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_domain.yml
@@ -1,14 +1,20 @@
-- block:
+---
+- name: Add storage domain main block
+  block:
     - name: Fetch available hosts in data center
       ovirt_host_info:
         pattern: "status=up and datacenter={{ storage['dr_' + dr_target_host + '_dc_name'] }}"
         auth: "{{ ovirt_auth }}"
       register: host_info
-    - block:
+
+    - name: Check for available hosts block
+      block:
         - name: "Check for available hosts"
           fail: msg="No hosts available"
           when: host_info.ovirt_hosts.0 is undefined
-    - block:
+
+    - name: Add storage domain block
+      block:
         - name: Add storage domain if NFS
           include_tasks: add_nfs_domain.yml
           with_items:
@@ -25,7 +31,7 @@
           loop_control:
             loop_var: gluster_storage
 
-        - name: Add storage domain if Posix
+        - name: Add storage domain if POSIX
           include_tasks: add_posixfs_domain.yml
           with_items:
             - "{{ storage }}"
@@ -33,7 +39,7 @@
           loop_control:
             loop_var: posix_storage
 
-        - name: Add storage domain is scsi
+        - name: Add storage domain if iSCSI
           include_tasks: add_iscsi_domain.yml
           with_items:
             - "{{ storage }}"
@@ -41,7 +47,7 @@
           loop_control:
             loop_var: iscsi_storage
 
-        - name: Add storage domain if fcp
+        - name: Add storage domain if FCP
           include_tasks: add_fcp_domain.yml
           with_items:
             - "{{ storage }}"

--- a/roles/disaster_recovery/tasks/recover/add_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_domain.yml
@@ -10,7 +10,7 @@
     - name: Check for available hosts block
       block:
         - name: "Check for available hosts"
-          fail: msg="No hosts available"
+          ansible.builtin.fail: msg="No hosts available"
           when: host_info.ovirt_hosts.0 is undefined
 
     - name: Add storage domain block

--- a/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
@@ -18,12 +18,12 @@
       register: result
 
     - name: Log append to succeed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       when: result is succeeded
 
     - name: Log append to failed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Import FCP storage domain main block
+  block:
     - name: Import FCP storage domain
       ovirt_storage_domain:
         state: imported

--- a/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_fcp_domain.yml
@@ -3,7 +3,7 @@
       ovirt_storage_domain:
         state: imported
         id: "{{ fcp_storage['dr_domain_id'] }}"
-        name: "{{ fcp_storage['dr_' + dr_target_host + '_name']|default('') }}"
+        name: "{{ fcp_storage['dr_' + dr_target_host + '_name'] | default('') }}"
         critical_space_action_blocker: "{{ fcp_storage['dr_critical_space_action_blocker'] }}"
         warning_low_space: "{{ fcp_storage['dr_warning_low_space'] }}"
         discard_after_delete: "{{ fcp_storage['dr_discard_after_delete'] }}"
@@ -17,12 +17,12 @@
 
     - name: Log append to succeed_storage_domains
       set_fact:
-        succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name']|default('') }}\" ]"
+        succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       when: result is succeeded
 
     - name: Log append to failed_storage_domains
       set_fact:
-        failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name']|default('') }}\" ]"
+        failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ fcp_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:

--- a/roles/disaster_recovery/tasks/recover/add_glusterfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_glusterfs_domain.yml
@@ -18,12 +18,12 @@
       register: result
 
     - name: Log append to succeed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ gluster_storage['dr_' + dr_target_host + '_name'] }}\" ]"
       when: result is succeeded
 
     - name: Log append to failed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ gluster_storage['dr_' + dr_target_host + '_name'] }}\" ]"
       when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/add_glusterfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_glusterfs_domain.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Add Gluster storage domain main block
+  block:
     - name: Add Gluster storage domain
       ovirt_storage_domain:
         name: "{{ gluster_storage['dr_' + dr_target_host + '_name'] }}"

--- a/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
@@ -1,7 +1,10 @@
-- block:
+---
+- name: Import iSCSI storage domain main block
+  block:
     # TODO: Add support for connect to multiple targets with the same LUN.
-    # Every connect should be done using a different ip
-    - block:
+    # Every connect should be done using a different IP.
+    - name: Import iSCSI storage domain block
+      block:
         - name: Login to iSCSI targets
           ovirt_host:
             state: iscsilogin

--- a/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
@@ -8,12 +8,12 @@
             name: "{{ host_info.ovirt_hosts[0].name }}"
             auth: "{{ ovirt_auth }}"
             iscsi:
-              username: "{{ iscsi_storage['dr_' + dr_target_host + '_username']|default('') }}"
-              password: "{{ iscsi_storage['dr_' + dr_target_host + '_password']|default('') }}"
+              username: "{{ iscsi_storage['dr_' + dr_target_host + '_username'] | default('') }}"
+              password: "{{ iscsi_storage['dr_' + dr_target_host + '_password'] | default('') }}"
               address: "{{ iscsi_storage['dr_' + dr_target_host + '_address'] }}"
               target: "{{ dr_target }}"
               # Make port to be optional
-              port: "{{ iscsi_storage['dr_' + dr_target_host + '_port']|default('3260'|int, true) }}"
+              port: "{{ iscsi_storage['dr_' + dr_target_host + '_port'] | default('3260' | int, true) }}"
           with_items:
             - "{{ iscsi_storage['dr_' + dr_target_host + '_target'] }}"
           loop_control:
@@ -23,7 +23,7 @@
           ovirt_storage_domain:
             state: imported
             id: "{{ iscsi_storage['dr_domain_id'] }}"
-            name: "{{ iscsi_storage['dr_' + dr_target_host + '_name']|default('') }}"
+            name: "{{ iscsi_storage['dr_' + dr_target_host + '_name'] | default('') }}"
             host: "{{ host_info.ovirt_hosts[0].name }}"
             auth: "{{ ovirt_auth }}"
             data_center: "{{ iscsi_storage['dr_' + dr_target_host + '_dc_name'] }}"
@@ -34,8 +34,8 @@
             backup: "{{ iscsi_storage['dr_backup'] }}"
             # TODO: For import iSCSI there is no need for the iscsi parameters
             iscsi:
-              username: "{{ iscsi_storage['dr_' + dr_target_host + '_username']|default('') }}"
-              password: "{{ iscsi_storage['dr_' + dr_target_host + '_password']|default('') }}"
+              username: "{{ iscsi_storage['dr_' + dr_target_host + '_username'] | default('') }}"
+              password: "{{ iscsi_storage['dr_' + dr_target_host + '_password'] | default('') }}"
               address: "{{ iscsi_storage['dr_' + dr_target_host + '_address'] }}"
               # We use target since state imported in ovirt_storage_domain.py creates a storage domain
               # which calls login, therefore we must have a target although the targets were already connected before.
@@ -47,11 +47,11 @@
             loop_var: dr_target
         - name: Log append to succeed_storage_domains
           set_fact:
-            succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name']|default('') }}\" ]"
+            succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       rescue:
         - name: Log append to failed_storage_domains
           set_fact:
-            failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name']|default('') }}\" ]"
+            failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:
     - fail_over

--- a/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_iscsi_domain.yml
@@ -49,11 +49,11 @@
           loop_control:
             loop_var: dr_target
         - name: Log append to succeed_storage_domains
-          set_fact:
+          ansible.builtin.set_fact:
             succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
       rescue:
         - name: Log append to failed_storage_domains
-          set_fact:
+          ansible.builtin.set_fact:
             failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ iscsi_storage['dr_' + dr_target_host + '_name'] | default('') }}\" ]"
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:

--- a/roles/disaster_recovery/tasks/recover/add_nfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_nfs_domain.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Add NFS storage domain main block
+  block:
     - name: Add NFS storage domain
       ovirt_storage_domain:
         name: "{{ nfs_storage['dr_' + dr_target_host + '_name'] }}"

--- a/roles/disaster_recovery/tasks/recover/add_nfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_nfs_domain.yml
@@ -15,12 +15,12 @@
           path: "{{ nfs_storage['dr_' + dr_target_host + '_path'] }}"
           address: "{{ nfs_storage['dr_' + dr_target_host + '_address'] }}"
     - name: Log append to successful storage domains
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ nfs_storage['dr_' + dr_target_host + '_name'] }}\" ]"
 
   rescue:
     - name: Log append to failed storage domains
-      set_fact:
+      ansible.builtin.set_fact:
         failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ nfs_storage['dr_' + dr_target_host + '_name'] }}\" ]"
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:

--- a/roles/disaster_recovery/tasks/recover/add_posixfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_posixfs_domain.yml
@@ -19,12 +19,12 @@
       register: result
 
     - name: Log append to succeed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_storage_domains: "{{ succeed_storage_domains }} + [ \"{{ posix_storage['dr_' + dr_target_host + '_name'] }}\" ]"
       when: result is succeeded
 
     - name: Log append to failed_storage_domains
-      set_fact:
+      ansible.builtin.set_fact:
         failed_storage_domains: "{{ failed_storage_domains }} + [ \"{{ posix_storage['dr_' + dr_target_host + '_name'] }}\" ]"
       when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/add_posixfs_domain.yml
+++ b/roles/disaster_recovery/tasks/recover/add_posixfs_domain.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Add posix storage domain
+---
+- name: Add POSIX storage domain main block
+  block:
+    - name: Add POSIX storage domain
       ovirt_storage_domain:
         name: "{{ posix_storage['dr_' + dr_target_host + '_name'] }}"
         critical_space_action_blocker: "{{ posix_storage['dr_critical_space_action_blocker'] }}"

--- a/roles/disaster_recovery/tasks/recover/print_info.yml
+++ b/roles/disaster_recovery/tasks/recover/print_info.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Print report file main block
+  block:
     - name: Generate log file through template
       template:
         src: report_log_template.j2

--- a/roles/disaster_recovery/tasks/recover/print_info.yml
+++ b/roles/disaster_recovery/tasks/recover/print_info.yml
@@ -9,6 +9,7 @@
 
     - name: Print report file
       ansible.builtin.command: cat /tmp/{{ dr_report_file }}
+      changed_when: false
       register: content
 
     - name: Print report file to stdout

--- a/roles/disaster_recovery/tasks/recover/print_info.yml
+++ b/roles/disaster_recovery/tasks/recover/print_info.yml
@@ -2,17 +2,17 @@
 - name: Print report file main block
   block:
     - name: Generate log file through template
-      template:
+      ansible.builtin.template:
         src: report_log_template.j2
         dest: /tmp/{{ dr_report_file }}
         mode: preserve
 
     - name: Print report file
-      command: cat /tmp/{{ dr_report_file }}
+      ansible.builtin.command: cat /tmp/{{ dr_report_file }}
       register: content
 
     - name: Print report file to stdout
-      debug: msg="{{ content.stdout_lines | quote }}"
+      ansible.builtin.debug: msg="{{ content.stdout_lines | quote }}"
   tags:
     - fail_over
     - fail_back

--- a/roles/disaster_recovery/tasks/recover/register_template.yml
+++ b/roles/disaster_recovery/tasks/recover/register_template.yml
@@ -15,12 +15,12 @@
       register: template_register_result
 
     - name: Log append failed template to failed_template_names
-      set_fact:
+      ansible.builtin.set_fact:
         failed_template_names: "{{ failed_template_names }} + [ '{{ unreg_template.name }}' ]"
       when: template_register_result is failed
 
     - name: Log append succeeded template succeed_template_names
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_template_names: "{{ succeed_template_names }} + [ '{{ unreg_template.name }}' ]"
       when: template_register_result is succeeded
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/register_template.yml
+++ b/roles/disaster_recovery/tasks/recover/register_template.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Register unregistered Template
+---
+- name: Register unregistered template main block
+  block:
+    - name: "Register unregistered template '{{ unreg_template.id }}'"
       ovirt_template:
         state: registered
         storage_domain: "{{ storage.name }}"
@@ -12,12 +14,12 @@
         role_mappings: "{{ dr_role_map }}"
       register: template_register_result
 
-    - name: Log append failed Template to issues failed_template_names
+    - name: Log append failed template to failed_template_names
       set_fact:
         failed_template_names: "{{ failed_template_names }} + [ '{{ unreg_template.name }}' ]"
       when: template_register_result is failed
 
-    - name: Log append succeed_template_names
+    - name: Log append succeeded template succeed_template_names
       set_fact:
         succeed_template_names: "{{ succeed_template_names }} + [ '{{ unreg_template.name }}' ]"
       when: template_register_result is succeeded

--- a/roles/disaster_recovery/tasks/recover/register_templates.yml
+++ b/roles/disaster_recovery/tasks/recover/register_templates.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Fetch unregistered Templates from storage domain
+---
+- name: Register unregistered templates main block
+  block:
+    - name: Fetch unregistered templates from storage domain
       ovirt_storage_template_info:
         nested_attributes: "id"
         unregistered: true
@@ -7,7 +9,7 @@
         auth: "{{ ovirt_auth }}"
       register: storage_template_info
 
-    - name: Register template
+    - name: Register unregistered templates
       include: register_template.yml
       # The main task is already declared to ignore errors so that might be
       # redundant to put it here ignore_errors: "{{ ignore | default(yes) }}"

--- a/roles/disaster_recovery/tasks/recover/register_vm.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vm.yml
@@ -19,12 +19,12 @@
       register: vm_register_result
 
     - name: Log append failed VM to failed_vm_names
-      set_fact:
+      ansible.builtin.set_fact:
         failed_vm_names: "{{ failed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
       when: vm_register_result is failed
 
     - name: Log append succeeded VM to succeed_vm_names
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_vm_names: "{{ succeed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
       when: vm_register_result is succeeded
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/register_vm.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vm.yml
@@ -1,5 +1,7 @@
-- block:
-    - name: Register VMs
+---
+- name: Register VM main block
+  block:
+    - name: Register VM
       ovirt_vm:
         state: registered
         storage_domain: "{{ storage.name }}"
@@ -21,7 +23,7 @@
         failed_vm_names: "{{ failed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
       when: vm_register_result is failed
 
-    - name: Log append succeed_vm_names
+    - name: Log append succeeded VM to succeed_vm_names
       set_fact:
         succeed_vm_names: "{{ succeed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
       when: vm_register_result is succeeded

--- a/roles/disaster_recovery/tasks/recover/register_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vms.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Register VMs main block
+  block:
     - name: Fetch unregistered VMs from storage domain
       ovirt_storage_vm_info:
         nested_attributes: "id"
@@ -12,7 +14,7 @@
         unreg_vms: "{{ unreg_vms | default([]) + storage_vm_info.ovirt_storage_vms }}"
 
     # TODO: We should filter out VMs which already exist in the setup (diskless VMs)
-    - name: Register VM
+    - name: Register VMs
       include: register_vm.yml
       with_items: "{{ storage_vm_info.ovirt_storage_vms }}"
       # We use loop_control so storage.name will not be overridden by the nested loop.

--- a/roles/disaster_recovery/tasks/recover/register_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vms.yml
@@ -9,7 +9,7 @@
 
     - name: Set unregistered VMs
       set_fact:
-        unreg_vms: "{{ unreg_vms|default([]) + storage_vm_info.ovirt_storage_vms }}"
+        unreg_vms: "{{ unreg_vms | default([]) + storage_vm_info.ovirt_storage_vms }}"
 
     # TODO: We should filter out VMs which already exist in the setup (diskless VMs)
     - name: Register VM

--- a/roles/disaster_recovery/tasks/recover/register_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vms.yml
@@ -10,7 +10,7 @@
       register: storage_vm_info
 
     - name: Set unregistered VMs
-      set_fact:
+      ansible.builtin.set_fact:
         unreg_vms: "{{ unreg_vms | default([]) + storage_vm_info.ovirt_storage_vms }}"
 
     # TODO: We should filter out VMs which already exist in the setup (diskless VMs)

--- a/roles/disaster_recovery/tasks/recover/run_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/run_vms.yml
@@ -9,12 +9,12 @@
         auth: "{{ ovirt_auth }}"
       register: result
     - name: Log append succeed_to_run_vms
-      set_fact:
+      ansible.builtin.set_fact:
         succeed_to_run_vms: "{{ succeed_to_run_vms }} + [ '{{ vms.name }}' ]"
       when: result is succeeded
 
     - name: Log append failed_to_run_vms
-      set_fact:
+      ansible.builtin.set_fact:
         failed_to_run_vms: "{{ failed_to_run_vms }} + [ '{{ vms.name }}' ]"
       when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/roles/disaster_recovery/tasks/recover/run_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/run_vms.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Run VMs main block
+  block:
     - name: Run VMs
       ovirt_vm:
         state: running

--- a/roles/disaster_recovery/tasks/recover_engine.yml
+++ b/roles/disaster_recovery/tasks/recover_engine.yml
@@ -151,7 +151,7 @@
             'dest_logical_unit_id': item[dr_target_host + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
             'dest_storage_type': item[dr_target_host + '_storage_type'] | default('EMPTY_ELEMENT', true),
             'dest_logical_unit_address': item[dr_target_host + '_logical_unit_address'] | default('EMPTY_ELEMENT', true),
-            'dest_logical_unit_port': item[dr_target_host + '_logical_unit_port'] | default('3260'|int, true),
+            'dest_logical_unit_port': item[dr_target_host + '_logical_unit_port'] | default('3260' | int, true),
             'dest_logical_unit_portal': item[dr_target_host + '_logical_unit_portal'] | default('1', true),
             'dest_logical_unit_username': item[dr_target_host + '_logical_unit_username'] | default('', true),
             'dest_logical_unit_password': item[dr_target_host + '_logical_unit_password'] | default('', true),

--- a/roles/disaster_recovery/tasks/recover_engine.yml
+++ b/roles/disaster_recovery/tasks/recover_engine.yml
@@ -10,19 +10,19 @@
       ignore_errors: false
 
     - name: Delete previous report log
-      file:
+      ansible.builtin.file:
         path: "/tmp/{{ dr_report_file }}"
         state: absent
       ignore_errors: true
 
     - name: Create report file
-      file:
+      ansible.builtin.file:
         path: "/tmp/{{ dr_report_file }}"
         state: touch
         mode: 0644
 
     - name: Init entity status list
-      set_fact:
+      ansible.builtin.set_fact:
         failed_vm_names: []
         succeed_vm_names: []
         failed_template_names: []
@@ -67,7 +67,7 @@
       register: storage_domain_info
 
     - name: Set initial Maps
-      set_fact:
+      ansible.builtin.set_fact:
         dr_cluster_map: "{{ [] }}"
         dr_affinity_group_map: "{{ [] }}"
         dr_affinity_label_map: "{{ [] }}"
@@ -77,7 +77,7 @@
         dr_network_map: "{{ [] }}"
 
     - name: Set Cluster Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_cluster_map: "{{ dr_cluster_map + [
         {
             'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
@@ -88,7 +88,7 @@
       when: dr_cluster_mappings is not none
 
     - name: Set Affinity Group Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_affinity_group_map: "{{ dr_affinity_group_map + [
         {
             'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
@@ -99,7 +99,7 @@
       when: dr_affinity_group_mappings is not none
 
     - name: Set Network Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_network_map: "{{ dr_network_map + [
         {
             'source_network_name': item[dr_source_map + '_network_name'] | default('EMPTY_ELEMENT', true),
@@ -112,7 +112,7 @@
       when: dr_network_mappings is not none
 
     - name: Set Affinity Label Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_affinity_label_map: "{{ dr_affinity_label_map + [
         {
             'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
@@ -123,7 +123,7 @@
       when: dr_affinity_label_mappings is not none
 
     - name: Set aaa extensions Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_domain_map: "{{ dr_domain_map + [
         {
             'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
@@ -134,7 +134,7 @@
       when: dr_domain_mappings is not none
 
     - name: Set Role Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_role_map: "{{ dr_role_map + [
         {
             'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
@@ -145,7 +145,7 @@
       when: dr_role_mappings is not none
 
     - name: Set Lun Map
-      set_fact:
+      ansible.builtin.set_fact:
         dr_lun_map: "{{ dr_lun_map + [
         {
             'source_logical_unit_id': item[dr_source_map + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),

--- a/roles/disaster_recovery/tasks/recover_engine.yml
+++ b/roles/disaster_recovery/tasks/recover_engine.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Recover engine main block
+  block:
     - name: Obtain SSO token
       ovirt_auth:
         url: "{{ vars['dr_sites_' + dr_target_host + '_url'] }}"

--- a/roles/disaster_recovery/tasks/run_unregistered_entities.yml
+++ b/roles/disaster_recovery/tasks/run_unregistered_entities.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Run unregistered entities main block
+  block:
     - name: Obtain SSO token
       ovirt_auth:
         url: "{{ vars['dr_sites_' + dr_target_host + '_url'] }}"
@@ -14,14 +16,14 @@
         path: "{{ dr_running_vms }}"
         state: absent
 
-    - name: Run all the high availability VMs
+    - name: Run all the (previously running) high availability VMs
       include_tasks: recover/run_vms.yml
       vars:
         vms: "{{ item }}"
       with_items: "{{ running_vms_fail_back }}"
       when: item.high_availability.enabled | bool
 
-    - name: Run all the entire running VMs
+    - name: Run all the (previously running) non high availability VMs
       include_tasks: recover/run_vms.yml
       vars:
         vms: "{{ item }}"

--- a/roles/disaster_recovery/tasks/run_unregistered_entities.yml
+++ b/roles/disaster_recovery/tasks/run_unregistered_entities.yml
@@ -9,10 +9,10 @@
         ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
 
     - name: Read file that contains running VMs from the previous setup
-      set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
+      ansible.builtin.set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
 
     - name: Remove dr_running_vms file after being used
-      file:
+      ansible.builtin.file:
         path: "{{ dr_running_vms }}"
         state: absent
 

--- a/roles/disaster_recovery/tasks/unregister_entities.yml
+++ b/roles/disaster_recovery/tasks/unregister_entities.yml
@@ -1,4 +1,6 @@
-- block:
+---
+- name: Unregister entities main block
+  block:
     - name: Obtain SSO token
       ovirt_auth:
         url: "{{ vars['dr_sites_' + dr_source_map + '_url'] }}"
@@ -18,7 +20,7 @@
         path: '{{ dr_running_vms }}'
       register: stat_result
 
-    - name: Fetch all data of running VMs from file, if exists.
+    - name: Fetch all data of running VMs from file, if exists
       set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
       when: stat_result.stat.exists
       ignore_errors: true
@@ -27,7 +29,7 @@
       set_fact:
         res_ovirt_vms="[]"
 
-    - name: Map all running vms in fact
+    - name: Map all running VMs in fact
       set_fact:
         res_ovirt_vms: "{{ res_ovirt_vms + [
         {
@@ -39,7 +41,7 @@
       with_items: "{{ vm_info.ovirt_vms }}"
       when: item.id is defined
 
-    - name: Create file to obtain running vms if file does not exist
+    - name: Create file to obtain running VMs if file does not exist
       file:
         path: '{{ dr_running_vms }}'
         state: touch

--- a/roles/disaster_recovery/tasks/unregister_entities.yml
+++ b/roles/disaster_recovery/tasks/unregister_entities.yml
@@ -16,21 +16,21 @@
       register: vm_info
 
     - name: Check whether file with running VMs info exists
-      stat:
+      ansible.builtin.stat:
         path: '{{ dr_running_vms }}'
       register: stat_result
 
     - name: Fetch all data of running VMs from file, if exists
-      set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
+      ansible.builtin.set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
       when: stat_result.stat.exists
       ignore_errors: true
 
     - name: Init list property for running_vms
-      set_fact:
+      ansible.builtin.set_fact:
         res_ovirt_vms="[]"
 
     - name: Map all running VMs in fact
-      set_fact:
+      ansible.builtin.set_fact:
         res_ovirt_vms: "{{ res_ovirt_vms + [
         {
             'id': item.id,
@@ -42,14 +42,14 @@
       when: item.id is defined
 
     - name: Create file to obtain running VMs if file does not exist
-      file:
+      ansible.builtin.file:
         path: '{{ dr_running_vms }}'
         state: touch
         mode: 0644
       when: not stat_result.stat.exists|bool or running_vms_fail_back is not defined
 
     - name: If no file exists which contains data of unregistered VMs, set the file with running VMs
-      copy: content="{{ res_ovirt_vms }}" dest={{ dr_running_vms }} mode="preserve"
+      ansible.builtin.copy: content="{{ res_ovirt_vms }}" dest={{ dr_running_vms }} mode="preserve"
       when: running_vms_fail_back is not defined or (running_vms_fail_back is defined and running_vms_fail_back | length == 0)
 
   ignore_errors: "{{ dr_ignore_error_clean }}"

--- a/roles/remove_stale_lun/examples/remove_stale_lun.yml
+++ b/roles/remove_stale_lun/examples/remove_stale_lun.yml
@@ -29,6 +29,6 @@
 
   roles:
     - role: remove_stale_lun
-      fetch_hosts: false 
+      fetch_hosts: false
   collections:
     - @NAMESPACE@.@NAME@

--- a/roles/remove_stale_lun/tasks/fetch_hosts.yml
+++ b/roles/remove_stale_lun/tasks/fetch_hosts.yml
@@ -3,7 +3,7 @@
 ## Ansible 2.3 generates a WARNING when using {{ }} in default variables of role
 ## these workarounds it until Ansible resolves the issue:
 - name: Initialize variables
-  set_fact:
+  ansible.builtin.set_fact:
     data_center: "{{ data_center | mandatory }}"
 
 - name: Fetch hosts main block

--- a/roles/remove_stale_lun/tasks/fetch_hosts.yml
+++ b/roles/remove_stale_lun/tasks/fetch_hosts.yml
@@ -1,12 +1,13 @@
 ---
 ## https://github.com/ansible/ansible/issues/22397
-## Ansible 2.3 generates a WARNING when using {{ }} in defaults variables of role
-## this workarounds it until Ansible resolves the issue:
+## Ansible 2.3 generates a WARNING when using {{ }} in default variables of role
+## these workarounds it until Ansible resolves the issue:
 - name: Initialize variables
   set_fact:
     data_center: "{{ data_center | mandatory }}"
 
-- block:
+- name: Fetch hosts main block
+  block:
     - name: Login to oVirt
       ovirt_auth:
         url: "{{ engine_url | default(lookup('env','OVIRT_URL')) | default(omit) }}"

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -7,11 +7,13 @@
     for dev in {{ lun_wwid }}; do
       set -euo pipefail && dmsetup deps -o devname $dev | cut -f 2 | cut -c 3- | tr -d "()" | tr "\r\n" " ";
     done
+  changed_when: false
   register: disks
   check_mode: "no"
 
 - name: Remove from multipath device.
   ansible.builtin.shell: "for dev in {{ lun_wwid }}; do multipath -f $dev || exit 1; done"
+  changed_when: true
   register: flush_results
   retries: 6
   check_mode: "no"
@@ -19,6 +21,7 @@
 
 - name: Remove each path from the SCSI subsystem.
   ansible.builtin.shell: "for dev in {{ item.stdout }}; do echo 1 > /sys/block/$dev/device/delete; done"
+  changed_when: true
   check_mode: "no"
   with_items:
     - "{{ disks }}"

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -1,5 +1,5 @@
 - name: Initialize variables
-  set_fact:
+  ansible.builtin.set_fact:
     lun_wwid: "{{ lun_wwid | mandatory }}"
 
 - name: Get underlying disks (paths) for a multipath device(s) and turn them into a list.

--- a/roles/remove_stale_lun/tasks/remove_mpath_device.yml
+++ b/roles/remove_stale_lun/tasks/remove_mpath_device.yml
@@ -3,7 +3,10 @@
     lun_wwid: "{{ lun_wwid | mandatory }}"
 
 - name: Get underlying disks (paths) for a multipath device(s) and turn them into a list.
-  ansible.builtin.shell: 'for dev in {{ lun_wwid }}; do dmsetup deps -o devname $dev | cut -f 2 |cut -c 3- |tr -d "()"|tr "\r\n" " "; done'
+  ansible.builtin.shell: >-
+    for dev in {{ lun_wwid }}; do
+      set -euo pipefail && dmsetup deps -o devname $dev | cut -f 2 | cut -c 3- | tr -d "()" | tr "\r\n" " ";
+    done
   register: disks
   check_mode: "no"
 


### PR DESCRIPTION
Fix the remaining `ansible-lint` version 6.0.0 violations for `disaster_recovery` & `remove_stale_lun` roles.

Fixing 106 failures.
26 `ignore-errors:` warnings - TBD.


Bug-Url: https://bugzilla.redhat.com/2097332