### PR TITLE
Fix: requirements for galaxy

### DIFF
--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -2,6 +2,7 @@
 version: 1
 dependencies:
   system: bindep.txt
+  galaxy: requirements.yml
   python: requirements.txt
 
 additional_build_steps:

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,7 @@
+---
+collections:
+  - name: ansible.netcommon
+    version: <3.0.0
+  - name: ansible.posix
+  - name: ansible.utils
+    version: <2.6.0


### PR DESCRIPTION
This is because of ipaddr which was moved from `ansible.netcommon` in version 3.0.0 to `ansible.utils` in version 2.6.0