### PR TITLE
CI: disable ansible-test for build

### DIFF
--- a/automation/build.sh
+++ b/automation/build.sh
@@ -66,7 +66,6 @@ mkdir -p $COLLECTION_DIR
 cp -r "$OVIRT_BUILD"/* "$COLLECTION_DIR"
 cd "$COLLECTION_DIR"
 
-ansible-test sanity
 antsibull-changelog lint -v
 ansible-lint roles/* --exclude roles/hosted_engine_setup --exclude roles/disaster_recovery --exclude roles/remove_stale_lun -x experimental
 ansible-lint -x var-spacing,unnamed-task,fqcn-builtins,no-changed-when,risky-shell-pipe,ignore-errors roles/disaster_recovery


### PR DESCRIPTION
After https://github.com/oVirt/ovirt-ansible-collection/commit/4a04b7042edf85d2f0e8cf93190f2a71a7458f21 we use containers to run the `ansible-test` for all versions. We no longer need to use it for pure build of the rpms