### PR TITLE
Improving the "ovirt_disk" documentation for disk extend flow

### DIFF
--- a/changelogs/fragments/559-update-documentation-ovirt_disk-requires-extra_params-when-extending-disk-with-non-unique-name.yml
+++ b/changelogs/fragments/559-update-documentation-ovirt_disk-requires-extra_params-when-extending-disk-with-non-unique-name.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Updating the documentation - "vm_name" / "vm_id" and/or disk "id" parameter(s) are required when extending disk with non-unique name (https://github.com/oVirt/ovirt-ansible-collection/pull/559).

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -73,6 +73,8 @@ options:
             - "Size of the disk. Size should be specified using IEC standard units.
                For example 10GiB, 1024MiB, etc."
             - "Size can be only increased, not decreased."
+            - "If the disk is referenced by C(name) and is attached to a VM, make sure to specify C(vm_name)/C(vm_id)
+               to prevent extension of another disk that is not attached to the VM."
         type: str
     interface:
         description:


### PR DESCRIPTION
If the disk is referenced by `name` and is attached to a VM, make sure to specify `vm_name` / `vm_id` to prevent extension of another disk that is not attached to the VM.

Bug-Url: https://bugzilla.redhat.com/2016638