### PR TITLE
hosted_engine_setup: fix HE VM networking on recent CentOS Stream

### DIFF
--- a/changelogs/fragments/561-he-vm-networking-cloud-init.yml
+++ b/changelogs/fragments/561-he-vm-networking-cloud-init.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - fix HE VM networking on recent CentOS Stream (https://github.com/oVirt/ovirt-ansible-collection/pull/561).

--- a/roles/hosted_engine_setup/templates/network-config-dhcp.j2
+++ b/roles/hosted_engine_setup/templates/network-config-dhcp.j2
@@ -3,9 +3,3 @@ config:
   - type: physical
     name: eth0
     mac_address: "{{ he_vm_mac_addr|lower }}"
-    subnets:
-{% if ipv6_deployment %}
-      - type: dhcp6
-{% else %}
-      - type: dhcp
-{% endif %}


### PR DESCRIPTION
When HostedEngineLocal boots up it applies the cloud init configuration.
For some reason it stopped working recently on dual stack where the VM
should be configured on IPv6 with IPv6 route set up to be reachanble
from host-0. Even though we configure dhcp6 on eth0 in cloud-init config
the route is not configured. Let's keep it as "auto" and let the OS pick
up the right thing, it seems to work ok.
