### PR TITLE
he-setup: ovn should be configured with he_host_name

### DIFF
--- a/changelogs/fragments/563-he-setup-configure-ovn-with-he-host-fqdn.yml
+++ b/changelogs/fragments/563-he-setup-configure-ovn-with-he-host-fqdn.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - During he_setup, configure ovn with he_host_name for correct operation of ovn (https://github.com/oVirt/ovirt-ansible-collection/pull/563).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -421,7 +421,7 @@
   # Keep this aligned with:
   # https://github.com/oVirt/ovirt-engine/blob/master/packaging/playbooks/roles/ovirt-provider-ovn-driver/tasks/main.yml
   - name: Reconfigure OVN central address
-    ansible.builtin.command: vdsm-tool ovn-config {{ engine_vm_ip.stdout_lines[0] }} {{ he_mgmt_network }}
+    ansible.builtin.command: vdsm-tool ovn-config {{ engine_vm_ip.stdout_lines[0] }} {{ he_mgmt_network }} {{ he_host_name }}
     environment: "{{ he_cmd_lang }}"
     changed_when: true
   # Workaround for https://bugzilla.redhat.com/1540107


### PR DESCRIPTION
The FQDN of the HE host is required in ovn-sbctl in order for OVN to
function after a fresh HE deploy.

Change-Id: I951f90a9bb035d52285a8c5800f4711aecf34ab6
Bug-Url: https://bugzilla.redhat.com/2107063
Signed-off-by: Eitan Raviv <eraviv@redhat.com>