### PR TITLE
roles: hosted_engine_setup: restore - remove host also based on name

### DIFF
--- a/changelogs/fragments/567-hosted_engine_setup-remove-host-based-on-name.yml
+++ b/changelogs/fragments/567-hosted_engine_setup-remove-host-based-on-name.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hosted_engine_setup - restore - remove host also based on name (https://github.com/oVirt/ovirt-ansible-collection/pull/567).

--- a/roles/hosted_engine_setup/tasks/restore_backup.yml
+++ b/roles/hosted_engine_setup/tasks/restore_backup.yml
@@ -49,7 +49,7 @@
   include_tasks: restore_host_redeploy.yml
   loop:
     - { vds_type: 'vds_name', input: "{{ he_host_name }}" }
-    - { vds_type: 'vds_id', input: "{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}" }
+    - { vds_type: 'vds_unique_id', input: "{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}" }
 - name: Rename previous HE storage domain to avoid name conflicts
   ansible.builtin.command: >-
     "{{ engine_psql }}" -c

--- a/roles/hosted_engine_setup/tasks/restore_backup.yml
+++ b/roles/hosted_engine_setup/tasks/restore_backup.yml
@@ -45,33 +45,11 @@
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_remove_old_enginevm
-- name: Update dynamic data for VMs on the host used to redeploy
-  ansible.builtin.command: >-
-    "{{ engine_psql }}" -c
-    "UPDATE vm_dynamic SET run_on_vds = NULL, status=0 /* Down */ WHERE run_on_vds IN
-    (SELECT vds_id FROM vds
-    WHERE upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}'))"
-  environment: "{{ he_cmd_lang }}"
-  changed_when: true
-  register: db_update_host_vms
-- name: Update dynamic data for VMs migrating to the host used to redeploy
-  ansible.builtin.command: >-
-    "{{ engine_psql }}" -c
-    "UPDATE vm_dynamic SET migrating_to_vds = NULL, status=0 /* Down */ WHERE migrating_to_vds IN
-    (SELECT vds_id FROM vds WHERE
-    upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}'))"
-  environment: "{{ he_cmd_lang }}"
-  changed_when: true
-  register: db_update_host_migrating_vms
-- name: Remove host used to redeploy
-  ansible.builtin.command: >-
-    "{{ engine_psql }}" -c
-    "SELECT deletevds(vds_id) FROM
-    (SELECT vds_id FROM vds WHERE
-    upper(vds_unique_id)=upper('{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}')) t"
-  environment: "{{ he_cmd_lang }}"
-  changed_when: true
-  register: db_remove_he_host
+- name: Update host used to redeploy
+  include_tasks: restore_host_redeploy.yml
+  loop:
+    - { vds_type: 'vds_name', input: "{{ he_host_name }}" }
+    - { vds_type: 'vds_id', input: "{{ hostvars[he_ansible_host_name]['unique_id_out']['stdout_lines']|first }}" }
 - name: Rename previous HE storage domain to avoid name conflicts
   ansible.builtin.command: >-
     "{{ engine_psql }}" -c

--- a/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
+++ b/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
@@ -1,0 +1,29 @@
+# Used by restore_backup.yml
+---
+- name: Update dynamic data for VMs on the host used to redeploy
+  ansible.builtin.command: >-
+    "{{ engine_psql }}" -c
+    "UPDATE vm_dynamic SET run_on_vds = NULL, status=0 /* Down */ WHERE run_on_vds IN
+    (SELECT vds_id FROM vds WHERE
+    upper("{{ item.vds_type }}")=upper("{{ item.input }}"))"
+  environment: "{{ he_cmd_lang }}"
+  changed_when: true
+  register: db_update_host_vms
+- name: Update dynamic data for VMs migrating to the host used to redeploy
+  ansible.builtin.command: >-
+    "{{ engine_psql }}" -c
+    "UPDATE vm_dynamic SET migrating_to_vds = NULL, status=0 /* Down */ WHERE migrating_to_vds IN
+    (SELECT vds_id FROM vds WHERE
+    upper("{{ item.vds_type }}")=upper("{{ item.input }}"))"
+  environment: "{{ he_cmd_lang }}"
+  changed_when: true
+  register: db_update_host_migrating_vms
+- name: Remove host used to redeploy
+  ansible.builtin.command: >-
+    "{{ engine_psql }}" -c
+    "SELECT deletevds(vds_id) FROM
+    (SELECT vds_id FROM vds WHERE
+    upper('{{ item.vds_type }}'')=upper('{{ item.input }}')) t"
+  environment: "{{ he_cmd_lang }}"
+  changed_when: true
+  register: db_remove_he_host

--- a/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
+++ b/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
@@ -5,7 +5,7 @@
     "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET run_on_vds = NULL, status=0 /* Down */ WHERE run_on_vds IN
     (SELECT vds_id FROM vds WHERE
-    upper("{{ item.vds_type }}")=upper("{{ item.input }}"))"
+    upper('{{ item.vds_type }}')=upper('{{ item.input }}'))"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_update_host_vms
@@ -14,7 +14,7 @@
     "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET migrating_to_vds = NULL, status=0 /* Down */ WHERE migrating_to_vds IN
     (SELECT vds_id FROM vds WHERE
-    upper("{{ item.vds_type }}")=upper("{{ item.input }}"))"
+    upper('{{ item.vds_type }}')=upper('{{ item.input }}'))"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_update_host_migrating_vms
@@ -23,7 +23,7 @@
     "{{ engine_psql }}" -c
     "SELECT deletevds(vds_id) FROM
     (SELECT vds_id FROM vds WHERE
-    upper('{{ item.vds_type }}'')=upper('{{ item.input }}')) t"
+    upper('{{ item.vds_type }}')=upper('{{ item.input }}')) t"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_remove_he_host

--- a/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
+++ b/roles/hosted_engine_setup/tasks/restore_host_redeploy.yml
@@ -5,7 +5,7 @@
     "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET run_on_vds = NULL, status=0 /* Down */ WHERE run_on_vds IN
     (SELECT vds_id FROM vds WHERE
-    upper('{{ item.vds_type }}')=upper('{{ item.input }}'))"
+    upper({{ item.vds_type }})=upper('{{ item.input }}'))"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_update_host_vms
@@ -14,7 +14,7 @@
     "{{ engine_psql }}" -c
     "UPDATE vm_dynamic SET migrating_to_vds = NULL, status=0 /* Down */ WHERE migrating_to_vds IN
     (SELECT vds_id FROM vds WHERE
-    upper('{{ item.vds_type }}')=upper('{{ item.input }}'))"
+    upper({{ item.vds_type }})=upper('{{ item.input }}'))"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_update_host_migrating_vms
@@ -23,7 +23,7 @@
     "{{ engine_psql }}" -c
     "SELECT deletevds(vds_id) FROM
     (SELECT vds_id FROM vds WHERE
-    upper('{{ item.vds_type }}')=upper('{{ item.input }}')) t"
+    upper({{ item.vds_type }})=upper('{{ item.input }}')) t"
   environment: "{{ he_cmd_lang }}"
   changed_when: true
   register: db_remove_he_host


### PR DESCRIPTION
In restore, remove the host from DB based on the name
in addition to the UUID.
Using multiple hosts with the same name is not allowed anyway.

Bug-Url: https://bugzilla.redhat.com/2003515
Signed-off-by: Asaf Rachmani <arachman@redhat.com>