### PR TITLE
he-setup: ovn should be configured with he_host_address

### DIFF
--- a/changelogs/fragments/568-he-setup-configure-ovn-with-he-host-fqdn.yml
+++ b/changelogs/fragments/568-he-setup-configure-ovn-with-he-host-fqdn.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - During he_setup, configure ovn with he__host_address (https://github.com/oVirt/ovirt-ansible-collection/pull/568).

--- a/changelogs/fragments/568-he-setup-configure-ovn-with-he-host-fqdn.yml
+++ b/changelogs/fragments/568-he-setup-configure-ovn-with-he-host-fqdn.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - During he_setup, configure ovn with he__host_address (https://github.com/oVirt/ovirt-ansible-collection/pull/568).
+  - During he_setup, configure ovn with he_host_address (https://github.com/oVirt/ovirt-ansible-collection/pull/568).

--- a/roles/hosted_engine_setup/README.md
+++ b/roles/hosted_engine_setup/README.md
@@ -38,8 +38,8 @@ Ansible version >= 2.9.21 and < 2.10.0
 | he_cluster_comp_version | null | Compatibility version of the hosted-engine cluster. Default value is the latest compatibility version |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
 | he_data_center_comp_version | null | Compatibility version of the hosted-engine data center. Default value is the latest compatibility version |
-| he_host_name | $(hostname -f) | name used by the engine for the first host |
-| he_host_address | $(hostname -f) | address used by the engine for the first host |
+| he_host_name | $(hostname -f) | Human readable name used by the engine for the first host |
+| he_host_address | $(hostname -f) | FQDN or IP address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |
 | he_force_ip4 | false | Force resolving engine FQDN to ipv4 only using DNS server |
 | he_force_ip6 | false | Force resolving engine FQDN to ipv6 only using DNS server |

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -421,7 +421,7 @@
   # Keep this aligned with:
   # https://github.com/oVirt/ovirt-engine/blob/master/packaging/playbooks/roles/ovirt-provider-ovn-driver/tasks/main.yml
   - name: Reconfigure OVN central address
-    ansible.builtin.command: vdsm-tool ovn-config {{ engine_vm_ip.stdout_lines[0] }} {{ he_mgmt_network }} {{ he_host_name }}
+    ansible.builtin.command: vdsm-tool ovn-config {{ engine_vm_ip.stdout_lines[0] }} {{ he_mgmt_network }} {{ he_host_address }}
     environment: "{{ he_cmd_lang }}"
     changed_when: true
   # Workaround for https://bugzilla.redhat.com/1540107


### PR DESCRIPTION
The FQDN of the HE host is returned by the variable he_host_address
and not by he_host_name.
This commit fixes commit 7ed85c7862fdb0f7ed7e5f61c771e85dc1774bbb,
(change-id I951f90a9bb035d52285a8c5800f4711aecf34ab6).

Change-Id: I22d97c869ffd0e05be652eb59b11b5e05db24b21
Bug-Url: https://bugzilla.redhat.com/2107063
Signed-off-by: Eitan Raviv <eraviv@redhat.com>