### PR TITLE
Add ansible-lint config

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,5 @@
+skip_list:
+ - ignore-errors
+ - var-spacing
+ - var-naming
+ - experimental

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -63,7 +63,7 @@ mv "$RHV_BUILD"/*tar.gz "$ROOT_PATH/exported-artifacts/"
 COLLECTION_DIR="/usr/local/share/ansible/collections/ansible_collections/ovirt/ovirt"
 export ANSIBLE_LIBRARY="$COLLECTION_DIR/plugins/modules"
 mkdir -p $COLLECTION_DIR
-cp -ar "$OVIRT_BUILD"/* "$COLLECTION_DIR"
+cp -r "$OVIRT_BUILD"/* "$OVIRT_BUILD"/.config "$COLLECTION_DIR"
 cd "$COLLECTION_DIR"
 
 antsibull-changelog lint -v

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -63,12 +63,11 @@ mv "$RHV_BUILD"/*tar.gz "$ROOT_PATH/exported-artifacts/"
 COLLECTION_DIR="/usr/local/share/ansible/collections/ansible_collections/ovirt/ovirt"
 export ANSIBLE_LIBRARY="$COLLECTION_DIR/plugins/modules"
 mkdir -p $COLLECTION_DIR
-cp -r "$OVIRT_BUILD"/* "$COLLECTION_DIR"
+cp -ar "$OVIRT_BUILD"/* "$COLLECTION_DIR"
 cd "$COLLECTION_DIR"
 
 antsibull-changelog lint -v
-ansible-lint roles/* --exclude roles/hosted_engine_setup -x experimental
-ansible-lint -x var-spacing,ignore-errors,var-naming roles/hosted_engine_setup
+ansible-lint roles/*
 
 cd "$ROOT_PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ build() {
     BUILD_PATH="$BUILD_PATH/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME/"
     mkdir -p "$BUILD_PATH"
     echo "The copying files to $BUILD_PATH"
-    cp -r ./* "$BUILD_PATH"
+    cp -r ./* .config/ "$BUILD_PATH"
     cd "$BUILD_PATH"
     rename
     dist


### PR DESCRIPTION
Add .ansible-lint config to skip var-spacing,ignore-errors,var-naming and experimental tests