### PR TITLE
repositories: RHV 4.4 SP1 is supported only on RHEL 8.6 EUS

### DIFF
--- a/changelogs/fragments/576-repositories-rhv-4.4-sp1-is-supported-only-on-rhel-8.6-eus.yml
+++ b/changelogs/fragments/576-repositories-rhv-4.4-sp1-is-supported-only-on-rhel-8.6-eus.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS (https://github.com/oVirt/ovirt-ansible-collection/pull/576).

--- a/roles/repositories/defaults/main.yml
+++ b/roles/repositories/defaults/main.yml
@@ -7,6 +7,7 @@ ovirt_repositories_clear: false
 ovirt_repositories_ovirt_version: 4.4
 ovirt_repositories_target_host: engine
 ovirt_repositories_subscription_manager_repos: []
+ovirt_repositories_subscription_manager_eus_repos: []
 ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools", "mod_auth_openidc:2.3", "nodejs:14"]
 ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12", "nodejs:14"]
 ovirt_repositories_ovirt_release_rpm_gpg: https://plain.resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v2

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -42,6 +42,12 @@
   ansible.builtin.include_vars: "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
   when: ovirt_repositories_subscription_manager_repos | list | length == 0
 
+- name: "Include {{ ovirt_repositories_target_host }}_eus_{{ ovirt_repositories_ovirt_version }}.yml variables"
+  ansible.builtin.include_vars: "{{ ovirt_repositories_target_host }}_eus_{{ ovirt_repositories_ovirt_version }}.yml"
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
+    - ovirt_repositories_subscription_manager_eus_repos | list | length == 0
+
 - name: Disable all repositories
   ansible.builtin.command: subscription-manager repos --disable=*
   when: ovirt_repositories_clear
@@ -50,6 +56,14 @@
   ansible.builtin.command: subscription-manager repos --enable={{ item }}
   changed_when: false
   with_items: "{{ ovirt_repositories_subscription_manager_repos }}"
+
+- name: Enable EUS repositories
+  ansible.builtin.command: subscription-manager repos --enable={{ item }}
+  changed_when: false
+  ignore_errors: true # EUS channels might not be available, so we cannot break the installation when there is a subscription error
+  with_items: "{{ ovirt_repositories_subscription_manager_eus_repos }}"
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
 
 - name: Fix RHEL version to 8.6
   ansible.builtin.command: subscription-manager release --set=8.6

--- a/roles/repositories/tasks/rh-subscription.yml
+++ b/roles/repositories/tasks/rh-subscription.yml
@@ -51,6 +51,12 @@
   changed_when: false
   with_items: "{{ ovirt_repositories_subscription_manager_repos }}"
 
+- name: Fix RHEL version to 8.6
+  ansible.builtin.command: subscription-manager release --set=8.6
+  changed_when: false
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
+
 - name: Enable dnf modules
   ansible.builtin.command: "dnf module enable -y {{ ovirt_repositories_rh_dnf_modules | join(' ') }}"
   args:

--- a/roles/repositories/tasks/satellite-subscription.yml
+++ b/roles/repositories/tasks/satellite-subscription.yml
@@ -12,6 +12,12 @@
     {% if ovirt_repositories_force_register is defined and ovirt_repositories_force_register|bool %} --force {% endif %}
   changed_when: false
 
+- name: Fix RHEL version to 8.6
+  ansible.builtin.command: subscription-manager release --set=8.6
+  changed_when: false
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
+
 - name: Enable dnf modules
   ansible.builtin.command: "dnf module enable -y {{ ovirt_repositories_rh_dnf_modules | join(' ') }}"
   args:

--- a/roles/repositories/vars/engine_eus_4.4.yml
+++ b/roles/repositories/vars/engine_eus_4.4.yml
@@ -1,0 +1,3 @@
+ovirt_repositories_subscription_manager_eus_repos:
+  - rhel-8-for-x86_64-baseos-eus-rpms
+  - rhel-8-for-x86_64-appstream-eus-rpms

--- a/roles/repositories/vars/host_eus_4.4.yml
+++ b/roles/repositories/vars/host_eus_4.4.yml
@@ -1,0 +1,3 @@
+ovirt_repositories_subscription_manager_eus_repos:
+  - rhel-8-for-x86_64-baseos-eus-rpms
+  - rhel-8-for-x86_64-appstream-eus-rpms

--- a/roles/repositories/vars/host_ppc_eus_4.4.yml
+++ b/roles/repositories/vars/host_ppc_eus_4.4.yml
@@ -1,0 +1,3 @@
+ovirt_repositories_subscription_manager_eus_repos:
+  - rhel-8-for-ppc64le-baseos-eus-rpms
+  - rhel-8-for-ppc64le-appstream-eus-rpms


### PR DESCRIPTION
RHV 4.4 SP1 is supported only on RHEL 8.6 EUS, so we need to prevent
customers to use it on RHEL 8.7+

Bug-Url: https://bugzilla.redhat.com/2108985
Signed-off-by: Martin Perina <mperina@redhat.com>
