### PR TITLE
Release 2.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v2.2.3
+======
+
+Minor Changes
+-------------
+
+- hosted_engine_setup - fix ovirt-provider-ovn-driver broken link (https://github.com/oVirt/ovirt-ansible-collection/pull/581).
+
+Bugfixes
+--------
+
+- cluster_upgrade - skip host upgrades without anything to update (https://github.com/oVirt/ovirt-ansible-collection/pull/580).
+- hosted_engine_setup - restore - remove host also based on name (https://github.com/oVirt/ovirt-ansible-collection/pull/567).
+- repositories - Fix example variable names (https://github.com/oVirt/ovirt-ansible-collection/pull/582).
+
 v2.2.2
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 VERSION="2.2.3"
-MILESTONE="master"
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+MILESTONE=""
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -833,3 +833,17 @@ releases:
     - 573-hosted_engine_setup-fetch-hosted-engine-ha-version-by-rpm-command.yml
     - 578-repositories-Add-mod_auth_openidc-and-nodejs-to-dnf-modules.yml
     release_date: '2022-08-09'
+  2.2.3:
+    changes:
+      bugfixes:
+      - cluster_upgrade - skip host upgrades without anything to update (https://github.com/oVirt/ovirt-ansible-collection/pull/580).
+      - hosted_engine_setup - restore - remove host also based on name (https://github.com/oVirt/ovirt-ansible-collection/pull/567).
+      - repositories - Fix example variable names (https://github.com/oVirt/ovirt-ansible-collection/pull/582).
+      minor_changes:
+      - hosted_engine_setup - fix ovirt-provider-ovn-driver broken link (https://github.com/oVirt/ovirt-ansible-collection/pull/581).
+    fragments:
+    - 567-hosted_engine_setup-remove-host-based-on-name.yml
+    - 580-cluster_upgrade-skip-host-upgrades-without-anything-to-update.yml
+    - 581-hosted_engine_setup-fix-broken-link.yml
+    - 582-repositories-fix-example-variable-names.yml
+    release_date: '2022-08-15'

--- a/changelogs/fragments/567-hosted_engine_setup-remove-host-based-on-name.yml
+++ b/changelogs/fragments/567-hosted_engine_setup-remove-host-based-on-name.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - hosted_engine_setup - restore - remove host also based on name (https://github.com/oVirt/ovirt-ansible-collection/pull/567).

--- a/changelogs/fragments/580-cluster_upgrade-skip-host-upgrades-without-anything-to-update.yml
+++ b/changelogs/fragments/580-cluster_upgrade-skip-host-upgrades-without-anything-to-update.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - cluster_upgrade - skip host upgrades without anything to update (https://github.com/oVirt/ovirt-ansible-collection/pull/580).

--- a/changelogs/fragments/581-hosted_engine_setup-fix-broken-link.yml
+++ b/changelogs/fragments/581-hosted_engine_setup-fix-broken-link.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - hosted_engine_setup - fix ovirt-provider-ovn-driver broken link (https://github.com/oVirt/ovirt-ansible-collection/pull/581).

--- a/changelogs/fragments/582-repositories-fix-example-variable-names.yml
+++ b/changelogs/fragments/582-repositories-fix-example-variable-names.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - repositories - Fix example variable names (https://github.com/oVirt/ovirt-ansible-collection/pull/582).

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -87,6 +87,12 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Mon Aug 15 2022 Martin Necas <mnecas@redhat.com> - 2.2.3-1
+- cluster_upgrade - Skip host upgrades without anything to update
+- hosted_engine_setup - Fix ovirt-provider-ovn-driver broken link
+- hosted_engine_setup - restore - Remove host also based on name
+- repositories - Fix example variable names
+
 * Tue Aug 9 2022 Martin Necas <mnecas@redhat.com> - 2.2.2-1
 - hosted_engine_setup - Detect hosted-engine-ha version using /usr/libexec/platform-python
 - hosted_engine_setup - update ansible version in README


### PR DESCRIPTION
v2.2.3
======

Minor Changes
-------------

- hosted_engine_setup - fix ovirt-provider-ovn-driver broken link (https://github.com/oVirt/ovirt-ansible-collection/pull/581).

Bugfixes
--------

- cluster_upgrade - skip host upgrades without anything to update (https://github.com/oVirt/ovirt-ansible-collection/pull/580).
- hosted_engine_setup - restore - remove host also based on name (https://github.com/oVirt/ovirt-ansible-collection/pull/567).
- repositories - Fix example variable names (https://github.com/oVirt/ovirt-ansible-collection/pull/582).