### PR TITLE
ovirt_host: reinstalled - honor activate and reboot_after_installation when false

### DIFF
--- a/changelogs/fragments/587-ovirt_host-honor-activate-and-reboot-params.yml
+++ b/changelogs/fragments/587-ovirt_host-honor-activate-and-reboot-params.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state (https://github.com/oVirt/ovirt-ansible-collection/pull/587).

--- a/plugins/modules/ovirt_host.py
+++ b/plugins/modules/ovirt_host.py
@@ -719,10 +719,11 @@ def main():
             )
 
             # Reinstall host:
-            hosts_module.action(
+            ret = hosts_module.action(
                 action='install',
                 action_condition=lambda h: h.status == hoststate.MAINTENANCE,
                 post_action=hosts_module.post_reinstall,
+                reboot=module.params.get('reboot_after_installation'),
                 wait_condition=lambda h: h.status == hoststate.MAINTENANCE,
                 fail_condition=hosts_module.failed_state_after_reinstall,
                 host=otypes.Host(
@@ -741,12 +742,13 @@ def main():
             )
 
             # Activate host after reinstall:
-            ret = hosts_module.action(
-                action='activate',
-                action_condition=lambda h: h.status == hoststate.MAINTENANCE,
-                wait_condition=lambda h: h.status == hoststate.UP,
-                fail_condition=failed_state,
-            )
+            if module.params['activate']:
+                ret = hosts_module.action(
+                    action='activate',
+                    action_condition=lambda h: h.status == hoststate.MAINTENANCE,
+                    wait_condition=lambda h: h.status == hoststate.UP,
+                    fail_condition=failed_state,
+                )
         module.exit_json(**ret)
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())


### PR DESCRIPTION
ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/586