### PR TITLE
CI: Fix ansible-lint

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -3,3 +3,8 @@ skip_list:
  - var-spacing
  - var-naming
  - experimental
+ - package-latest
+warn_list:
+ - name
+ - no-changed-when
+ - fqcn-builtins


### PR DESCRIPTION
The new version of ansible-lint adds a few new checks this PR makes the errors just warnings and we can fix them in the future. 