### PR TITLE
he_setup: fix static ipv6 ifcfg setup

### DIFF
--- a/changelogs/fragments/592-he-setup-static-ipv6.yml
+++ b/changelogs/fragments/592-he-setup-static-ipv6.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - he-setup - fix static ipv6 ifcfg setup (https://github.com/oVirt/ovirt-ansible-collection/pull/592).

--- a/roles/hosted_engine_setup/templates/ifcfg-eth0-static-ipv6.j2
+++ b/roles/hosted_engine_setup/templates/ifcfg-eth0-static-ipv6.j2
@@ -7,6 +7,7 @@ TYPE=Ethernet
 USERCTL=no
 ZONE=public
 IPV6INIT=yes
+IPV6_AUTOCONF=no
 IPV6ADDR={{ he_vm_ip_addr }}/{{ he_vm_ip_prefix }}
 IPV6_DEFAULTGW={{ he_gateway }}
 {% if he_dns_addr is string %}


### PR DESCRIPTION
Setting up a static ipv6 for a hosted engine VM is achieved by passing an ifcg script file to the VM. This file should contain the setting IPV6_AUTOCONF=no in order for nmcli to fully configure the connection as static.

Change-Id: Ib36e14d15382cbe543d001d1005aa7683e4d7848
Bug-Url: https://bugzilla.redhat.com/2125658
Signed-off-by: Eitan Raviv <eraviv@redhat.com>