### PR TITLE
ovirt_disk: Add read_only param for disk attachments

### DIFF
--- a/changelogs/fragments/597-ovirt_disk-add-read_only-param.yml
+++ b/changelogs/fragments/597-ovirt_disk-add-read_only-param.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ovirt_disk - Add read_only param for disk attachments (https://github.com/oVirt/ovirt-ansible-collection/pull/597).

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -745,6 +745,7 @@ class DiskAttachmentsModule(DisksModule):
             ) if self._module.params.get('interface') else None,
             bootable=self._module.params.get('bootable'),
             active=self.param('activate'),
+            read_only=self.param('read_only'),
             uses_scsi_reservation=self.param('uses_scsi_reservation'),
             pass_discard=self.param('pass_discard'),
         )
@@ -755,6 +756,7 @@ class DiskAttachmentsModule(DisksModule):
             equal(self._module.params.get('interface'), str(entity.interface)) and
             equal(self._module.params.get('bootable'), entity.bootable) and
             equal(self._module.params.get('pass_discard'), entity.pass_discard) and
+            equal(self._module.params.get('read_only'), entity.read_only) and
             equal(self._module.params.get('uses_scsi_reservation'), entity.uses_scsi_reservation) and
             equal(self.param('activate'), entity.active)
         )
@@ -820,6 +822,7 @@ def main():
         pass_discard=dict(default=None, type='bool'),
         propagate_errors=dict(default=None, type='bool'),
         logical_unit=dict(default=None, type='dict'),
+        read_only=dict(default=None, type='bool'),
         download_image_path=dict(default=None),
         upload_image_path=dict(default=None, aliases=['image_path']),
         force=dict(default=False, type='bool'),

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -140,6 +140,10 @@ options:
         description:
             - "I(True) if the disk should be shareable. By default when disk is created it isn't shareable."
         type: bool
+    read_only:
+        description:
+            - "I(True) if the disk should be read_only. By default when disk is created it isn't read_only."
+        type: bool
     logical_unit:
         description:
             - "Dictionary which describes LUN to be directly attached to VM:"


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/594 
Add read_only param for disk attachments