### PR TITLE
CI: ansible-lint update warn_lists and skip_list

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -4,7 +4,10 @@ skip_list:
  - var-naming
  - experimental
  - package-latest
+ - name[casing]
+ - name[template]
 warn_list:
- - name
  - no-changed-when
  - fqcn-builtins
+ - template-instead-of-copy
+ - jinja[invalid]


### PR DESCRIPTION
Temporarily fixes the CI fails of the ansible-lint