### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v2.3.0
+======
+
+Minor Changes
+-------------
+
+- filters - Add documentation to all filters (https://github.com/oVirt/ovirt-ansible-collection/pull/603).
+- ovirt_disk - Add read_only param for disk attachments (https://github.com/oVirt/ovirt-ansible-collection/pull/597).
+- ovirt_disk - Fix disk attachment to VM (https://github.com/oVirt/ovirt-ansible-collection/pull/361).
+
+Bugfixes
+--------
+
+- Fix ovirtvmipsv4 when using attribute (https://github.com/oVirt/ovirt-ansible-collection/pull/596).
+- he-setup - fix static ipv6 ifcfg setup (https://github.com/oVirt/ovirt-ansible-collection/pull/592).
+- ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state (https://github.com/oVirt/ovirt-ansible-collection/pull/587).
+- repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS (https://github.com/oVirt/ovirt-ansible-collection/pull/576).
+
 v2.2.3
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VERSION="2.2.4"
-MILESTONE="master"
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+VERSION="2.3.0"
+MILESTONE=""
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -847,3 +847,24 @@ releases:
     - 581-hosted_engine_setup-fix-broken-link.yml
     - 582-repositories-fix-example-variable-names.yml
     release_date: '2022-08-15'
+  2.3.0:
+    changes:
+      bugfixes:
+      - Fix ovirtvmipsv4 when using attribute (https://github.com/oVirt/ovirt-ansible-collection/pull/596).
+      - he-setup - fix static ipv6 ifcfg setup (https://github.com/oVirt/ovirt-ansible-collection/pull/592).
+      - ovirt_host - Honor activate and reboot_after_installation when they are set
+        to false with reinstalled host state (https://github.com/oVirt/ovirt-ansible-collection/pull/587).
+      - repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS (https://github.com/oVirt/ovirt-ansible-collection/pull/576).
+      minor_changes:
+      - filters - Add documentation to all filters (https://github.com/oVirt/ovirt-ansible-collection/pull/603).
+      - ovirt_disk - Add read_only param for disk attachments (https://github.com/oVirt/ovirt-ansible-collection/pull/597).
+      - ovirt_disk - Fix disk attachment to VM (https://github.com/oVirt/ovirt-ansible-collection/pull/361).
+    fragments:
+    - 361-ovirt_disk-fix-disk-attachment.yml
+    - 576-repositories-rhv-4.4-sp1-is-supported-only-on-rhel-8.6-eus.yml
+    - 587-ovirt_host-honor-activate-and-reboot-params.yml
+    - 592-he-setup-static-ipv6.yml
+    - 596-fix-ovirtvmipsv4-when-using-attr.yml
+    - 597-ovirt_disk-add-read_only-param.yml
+    - 603-add-filter-docs.yml
+    release_date: '2022-10-13'

--- a/changelogs/fragments/361-ovirt_disk-fix-disk-attachment.yml
+++ b/changelogs/fragments/361-ovirt_disk-fix-disk-attachment.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - ovirt_disk - Fix disk attachment to VM (https://github.com/oVirt/ovirt-ansible-collection/pull/361).

--- a/changelogs/fragments/576-repositories-rhv-4.4-sp1-is-supported-only-on-rhel-8.6-eus.yml
+++ b/changelogs/fragments/576-repositories-rhv-4.4-sp1-is-supported-only-on-rhel-8.6-eus.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-    - repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS (https://github.com/oVirt/ovirt-ansible-collection/pull/576).

--- a/changelogs/fragments/587-ovirt_host-honor-activate-and-reboot-params.yml
+++ b/changelogs/fragments/587-ovirt_host-honor-activate-and-reboot-params.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state (https://github.com/oVirt/ovirt-ansible-collection/pull/587).

--- a/changelogs/fragments/592-he-setup-static-ipv6.yml
+++ b/changelogs/fragments/592-he-setup-static-ipv6.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - he-setup - fix static ipv6 ifcfg setup (https://github.com/oVirt/ovirt-ansible-collection/pull/592).

--- a/changelogs/fragments/596-fix-ovirtvmipsv4-when-using-attr.yml
+++ b/changelogs/fragments/596-fix-ovirtvmipsv4-when-using-attr.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Fix ovirtvmipsv4 when using attribute (https://github.com/oVirt/ovirt-ansible-collection/pull/596).

--- a/changelogs/fragments/597-ovirt_disk-add-read_only-param.yml
+++ b/changelogs/fragments/597-ovirt_disk-add-read_only-param.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - ovirt_disk - Add read_only param for disk attachments (https://github.com/oVirt/ovirt-ansible-collection/pull/597).

--- a/changelogs/fragments/603-add-filter-docs.yml
+++ b/changelogs/fragments/603-add-filter-docs.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - filters - Add documentation to all filters (https://github.com/oVirt/ovirt-ansible-collection/pull/603).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "@NAMESPACE@"
 name: "@NAME@"
-version: 2.2.4
+version: 2.3.0
 authors:
     - Martin Necas <mnecas@redhat.com>
 license:

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -87,6 +87,15 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Thu Oct 13 2022 Martin Necas <mnecas@redhat.com> - 2.3.0-1
+- ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state
+- ovirt_disk - Add read_only param for disk attachments
+- ovirt_disk - Fix disk attachment to VM
+- filters - Add documentation to all filters
+- filters- Fix ovirtvmipsv4 when using attribute
+- he-setup - Fix static ipv6 ifcfg setup
+- repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS
+
 * Mon Aug 15 2022 Martin Necas <mnecas@redhat.com> - 2.2.3-1
 - cluster_upgrade - Skip host upgrades without anything to update
 - hosted_engine_setup - Fix ovirt-provider-ovn-driver broken link


### PR DESCRIPTION

v2.3.0
======

Minor Changes
-------------

- filters - Add documentation to all filters (https://github.com/oVirt/ovirt-ansible-collection/pull/603).
- ovirt_disk - Add read_only param for disk attachments (https://github.com/oVirt/ovirt-ansible-collection/pull/597).
- ovirt_disk - Fix disk attachment to VM (https://github.com/oVirt/ovirt-ansible-collection/pull/361).

Bugfixes
--------

- Fix ovirtvmipsv4 when using attribute (https://github.com/oVirt/ovirt-ansible-collection/pull/596).
- he-setup - fix static ipv6 ifcfg setup (https://github.com/oVirt/ovirt-ansible-collection/pull/592).
- ovirt_host - Honor activate and reboot_after_installation when they are set to false with reinstalled host state (https://github.com/oVirt/ovirt-ansible-collection/pull/587).
- repositories - RHV 4.4 SP1 is supported only on RHEL 8.6 EUS (https://github.com/oVirt/ovirt-ansible-collection/pull/576).
