### PR TITLE
filters: Fix ovirtvmipsv4 with attribute and network

### DIFF
--- a/changelogs/fragments/607-filters-fix-ovirtvmipsv4-with-atribute-and-network.yml
+++ b/changelogs/fragments/607-filters-fix-ovirtvmipsv4-with-atribute-and-network.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - filters - Fix ovirtvmipsv4 with attribute and network (https://github.com/oVirt/ovirt-ansible-collection/pull/607).

--- a/plugins/filter/ovirtvmip.py
+++ b/plugins/filter/ovirtvmip.py
@@ -72,7 +72,7 @@ class FilterModule(object):
         'Return list of IPv4 IPs'
         ips = self._parse_ips(ovirt_vms, lambda version: version == 'v4', attr)
         if attr:
-            return dict((k, v) for k, v in ips.items() if self.__address_in_network(v, network_ip))
+            return dict((k, list(filter(lambda x: self.__address_in_network(x, network_ip), v))) for k, v in ips.items())
         return filter(lambda x: self.__address_in_network(x, network_ip), ips)
 
     def ovirtvmipv6(self, ovirt_vms, attr=None, network_ip=None):


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/593#issuecomment-1279687954
Issue: When filtering the vms with atr and network the filter failed because we were checking list of ips insead of single ip