### PR TITLE
ovirtvmipsv4: Fix filter list

### DIFF
--- a/changelogs/fragments/609-filterip4-fix-filter-list.yml
+++ b/changelogs/fragments/609-filterip4-fix-filter-list.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - filters - Fix ovirtvmipsv4 with filter to list (https://github.com/oVirt/ovirt-ansible-collection/pull/609).

--- a/plugins/filter/ovirtvmip.py
+++ b/plugins/filter/ovirtvmip.py
@@ -73,7 +73,7 @@ class FilterModule(object):
         ips = self._parse_ips(ovirt_vms, lambda version: version == 'v4', attr)
         if attr:
             return dict((k, list(filter(lambda x: self.__address_in_network(x, network_ip), v))) for k, v in ips.items())
-        return filter(lambda x: self.__address_in_network(x, network_ip), ips)
+        return list(filter(lambda x: self.__address_in_network(x, network_ip), ips))
 
     def ovirtvmipv6(self, ovirt_vms, attr=None, network_ip=None):
         'Return first IPv6 IP'


### PR DESCRIPTION
error:
```
10:42:15 TASK [wait-for-vm-ip : Wait for VM IP] *****************************************
10:42:17 fatal: [[](/)]: FAILED! => {"msg": "The conditional check 'vm_info.ovirt_vms | ovirt.ovirt.ovirtvmipv4 | length > 0' failed. The error was: Unexpected templating type error occurred on ({% if vm_info.ovirt_vms | ovirt.ovirt.ovirtvmipv4 | length > 0 %} True {% else %} False {% endif %}): object of type 'filter' has no len()"}
```