### PR TITLE
Set ansible-lint>=6.0.0,<6.8.3 for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Install python3.8 modules
         if: ${{ matrix.shortcut == 'cs8' }}
-        run: pip-3.8 install pycodestyle pylint voluptuous yamllint "rstcheck<3.5.0" antsibull-changelog "rich<11.0.0" "ansible-lint>=6.0.0,<7.0.0" cryptography
+        run: pip-3.8 install pycodestyle pylint voluptuous yamllint "rstcheck<3.5.0" antsibull-changelog "rich<11.0.0" "ansible-lint>=6.0.0,<6.8.3" cryptography
 
       - name: Install ansible-core 2.13 on el9stream
         # Remove after ansible-core 2.13 is available on el9stream as RPM.
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install python3.9 modules
         if: ${{ matrix.shortcut == 'cs9' }}
-        run: pip-3 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<7.0.0" cryptography
+        run: pip-3 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<6.8.3" cryptography
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
In centos stream 9 the CI ansible-lint fails with:
```
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/__main__.py", line 317, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/__main__.py", line 269, in main
    return app.report_outcome(result, mark_as_success=mark_as_success)
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/app.py", line 201, in report_outcome
    self.report_summary(
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/app.py", line 294, in report_summary
    version_warning = get_version_warning()
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/config.py", line 289, in get_version_warning
    pip = guess_install_method()
  File "/usr/local/lib/python3.9/site-packages/ansiblelint/config.py", line 234, in guess_install_method
    for _ in uninstallation_paths(dist):
  File "/usr/lib/python3.9/site-packages/pip/_internal/req/req_uninstall.py", line 56, in unique
    for item in fn(*args, **kw):
  File "/usr/lib/python3.9/site-packages/pip/_internal/req/req_uninstall.py", line 79, in uninstallation_paths
    r = csv.reader(dist.get_metadata_lines('RECORD'))
AttributeError: 'Distribution' object has no attribute 'get_metadata_lines'
Error: Process completed with exit code 1.
```