### PR TITLE
cluster_upgrade: Fix the engine_correlation_id location

### DIFF
--- a/changelogs/fragments/637-cluster_upgrade-fix-the-engine_correlation_id-location.yml
+++ b/changelogs/fragments/637-cluster_upgrade-fix-the-engine_correlation_id-location.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cluster_upgrade - Fix the engine_correlation_id location (https://github.com/oVirt/ovirt-ansible-collection/pull/637).

--- a/roles/cluster_upgrade/defaults/main.yml
+++ b/roles/cluster_upgrade/defaults/main.yml
@@ -14,4 +14,3 @@ pinned_vms_names: []
 healing_in_progress_checks: 6
 healing_in_progress_check_delay: 300
 wait_to_finish_healing: 5
-engine_correlation_id: "{{ 99999999 | random | to_uuid }}"

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -6,6 +6,7 @@
   ansible.builtin.set_fact:
     stop_non_migratable_vms: "{{ stop_non_migratable_vms }}"
     provided_token: "{{ engine_token | default(lookup('env','OVIRT_TOKEN')) | default('') }}"
+    engine_correlation_id: "{{ 99999999 | random | to_uuid }}"
 
 - name: Main block
   block:


### PR DESCRIPTION
Issue:
When there is `random` filter in the ansible defaults, and the value is not specified, it does not generate one random number per run but per each use of the unset variable.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2142601