### PR TITLE
DR-Failback errors when gathering/detecting HA VM as well as storage domains

### DIFF
--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -20,7 +20,7 @@
     - name: Fetch detached storage domain for remove
       ovirt_storage_domain_info:
         pattern: >
-           name={{ storage['dr_' + dr_source_map + '_name'] }} and
+          name={{ storage['dr_' + dr_source_map + '_name'] }} and
             datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_unattached_domain_search }} 
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_detached

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -4,7 +4,7 @@
     - name: Fetch active storage domain for remove
       ovirt_storage_domain_info:
         pattern: >
-           name={{ storage['dr_' + dr_source_map + '_name'] }} and
+          name={{ storage['dr_' + dr_source_map + '_name'] }} and
             datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }}
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_active
@@ -24,22 +24,6 @@
             datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} 
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_active
-
-    - name: Fetch maintenance storage domain for remove
-      ovirt_storage_domain_info:
-        pattern: >
-          name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} 
-        auth: "{{ ovirt_auth }}"
-      register: storage_domain_info_maintenance
-
-    - name: Fetch detached storage domain for remove
-      ovirt_storage_domain_info:
-        pattern: >
-          name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            {{ dr_unattached_domain_search }}
-        auth: "{{ ovirt_auth }}"
-      register: storage_domain_info_detached
 
     - name: Remove valid storage domain
       include_tasks: remove_domain_process.yml

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove valid storage domain main block
   block:
-    - name: Fetch active/maintenance/detached storage domain for remove
+    - name: Fetch active storage domain for remove
       ovirt_storage_domain_info:
         pattern: >
            name={{ storage['dr_' + dr_source_map + '_name'] }} and

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -4,21 +4,35 @@
     - name: Fetch active/maintenance/detached storage domain for remove
       ovirt_storage_domain_info:
         pattern: >
-          name={{ storage['dr_' + dr_source_map + '_name'] }} and
-          (
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} or
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} or
-            {{ dr_unattached_domain_search }}
-          )
+           name={{ storage['dr_' + dr_source_map + '_name'] }} and
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} 
         auth: "{{ ovirt_auth }}"
-      register: storage_domain_info
+      register: storage_domain_info_active
+
+    - name: Fetch maintenance storage domain for remove
+      ovirt_storage_domain_info:
+        pattern: >
+          name={{ storage['dr_' + dr_source_map + '_name'] }} and
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} 
+        auth: "{{ ovirt_auth }}"
+      register: storage_domain_info_maintenance
+
+    - name: Fetch detached storage domain for remove
+      ovirt_storage_domain_info:
+        pattern: >
+          name={{ storage['dr_' + dr_source_map + '_name'] }} and
+            {{ dr_unattached_domain_search }}
+        auth: "{{ ovirt_auth }}"
+      register: storage_domain_info_detached
 
     - name: Remove valid storage domain
       include_tasks: remove_domain_process.yml
       vars:
         sd: "{{ sd }}"
       with_items:
-        - "{{ storage_domain_info.ovirt_storage_domains }}"
+        - "{{ storage_domain_info_active.ovirt_storage_domains }}"
+        - "{{ storage_domain_info_maintenance.ovirt_storage_domains }}"
+        - "{{ storage_domain_info_detached.ovirt_storage_domains }}" 
       when: (not only_master and not sd.master) or (only_master and sd.master)
       loop_control:
         loop_var: sd

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -5,7 +5,7 @@
       ovirt_storage_domain_info:
         pattern: >
            name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} 
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }}
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_active
 
@@ -13,7 +13,7 @@
       ovirt_storage_domain_info:
         pattern: >
           name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} 
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }}
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_maintenance
 

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -20,6 +20,22 @@
     - name: Fetch detached storage domain for remove
       ovirt_storage_domain_info:
         pattern: >
+           name={{ storage['dr_' + dr_source_map + '_name'] }} and
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} 
+        auth: "{{ ovirt_auth }}"
+      register: storage_domain_info_active
+
+    - name: Fetch maintenance storage domain for remove
+      ovirt_storage_domain_info:
+        pattern: >
+          name={{ storage['dr_' + dr_source_map + '_name'] }} and
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} 
+        auth: "{{ ovirt_auth }}"
+      register: storage_domain_info_maintenance
+
+    - name: Fetch detached storage domain for remove
+      ovirt_storage_domain_info:
+        pattern: >
           name={{ storage['dr_' + dr_source_map + '_name'] }} and
             {{ dr_unattached_domain_search }}
         auth: "{{ ovirt_auth }}"

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -21,7 +21,7 @@
       ovirt_storage_domain_info:
         pattern: >
           name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_unattached_domain_search }} 
+            {{ dr_unattached_domain_search }}
         auth: "{{ ovirt_auth }}"
       register: storage_domain_info_detached
 

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -32,7 +32,7 @@
       with_items:
         - "{{ storage_domain_info_active.ovirt_storage_domains }}"
         - "{{ storage_domain_info_maintenance.ovirt_storage_domains }}"
-        - "{{ storage_domain_info_detached.ovirt_storage_domains }}" 
+        - "{{ storage_domain_info_detached.ovirt_storage_domains }}"
       when: (not only_master and not sd.master) or (only_master and sd.master)
       loop_control:
         loop_var: sd

--- a/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/roles/disaster_recovery/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -21,9 +21,9 @@
       ovirt_storage_domain_info:
         pattern: >
            name={{ storage['dr_' + dr_source_map + '_name'] }} and
-            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} 
+            datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_unattached_domain_search }} 
         auth: "{{ ovirt_auth }}"
-      register: storage_domain_info_active
+      register: storage_domain_info_detached
 
     - name: Remove valid storage domain
       include_tasks: remove_domain_process.yml

--- a/roles/disaster_recovery/tasks/unregister_entities.yml
+++ b/roles/disaster_recovery/tasks/unregister_entities.yml
@@ -27,7 +27,7 @@
 
     - name: Init list property for running_vms
       ansible.builtin.set_fact:
-        res_ovirt_vms="[]"
+        res_ovirt_vms=[]
 
     - name: Map all running VMs in fact
       ansible.builtin.set_fact:


### PR DESCRIPTION

DR-Failback errors when gathering/detecting HA VM as well as storage domains
Issue:
Storage domain detection was not finding any storage domains due to incorrect conditional checks.
Failback operation with a Highly Available VM but encountered an Unexpected templating type error occurred on that must be str, not list 
Fix:
Created separate tasks for detecting domains in various states and fixed conditional checks.
Removed redundant variable quotes.


Signed-off-by: Shubha Kulkarni <shubha.kulkarni@oracle.com>
