### PR TITLE
Backport: info modules: use @NAMESPACE@.@NAME@ instead of ovirt.ovirt for deprecation warning

### DIFF
--- a/changelogs/fragments/653-info-modules-use-dynamic-name.yml
+++ b/changelogs/fragments/653-info-modules-use-dynamic-name.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).

--- a/plugins/modules/ovirt_affinity_label_info.py
+++ b/plugins/modules/ovirt_affinity_label_info.py
@@ -134,7 +134,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_cluster_info.py
+++ b/plugins/modules/ovirt_cluster_info.py
@@ -102,7 +102,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_datacenter_info.py
+++ b/plugins/modules/ovirt_datacenter_info.py
@@ -86,7 +86,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_disk_info.py
+++ b/plugins/modules/ovirt_disk_info.py
@@ -99,7 +99,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_event_info.py
+++ b/plugins/modules/ovirt_event_info.py
@@ -132,7 +132,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_external_provider_info.py
+++ b/plugins/modules/ovirt_external_provider_info.py
@@ -139,7 +139,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_group_info.py
+++ b/plugins/modules/ovirt_group_info.py
@@ -98,7 +98,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_host_info.py
+++ b/plugins/modules/ovirt_host_info.py
@@ -117,7 +117,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_host_storage_info.py
+++ b/plugins/modules/ovirt_host_storage_info.py
@@ -150,7 +150,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_network_info.py
+++ b/plugins/modules/ovirt_network_info.py
@@ -102,7 +102,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_nic_info.py
+++ b/plugins/modules/ovirt_nic_info.py
@@ -116,7 +116,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_permission_info.py
+++ b/plugins/modules/ovirt_permission_info.py
@@ -147,7 +147,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_quota_info.py
+++ b/plugins/modules/ovirt_quota_info.py
@@ -106,7 +106,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_scheduling_policy_info.py
+++ b/plugins/modules/ovirt_scheduling_policy_info.py
@@ -106,7 +106,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_snapshot_info.py
+++ b/plugins/modules/ovirt_snapshot_info.py
@@ -99,7 +99,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_storage_domain_info.py
+++ b/plugins/modules/ovirt_storage_domain_info.py
@@ -102,7 +102,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_storage_template_info.py
+++ b/plugins/modules/ovirt_storage_template_info.py
@@ -113,7 +113,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_storage_vm_info.py
+++ b/plugins/modules/ovirt_storage_vm_info.py
@@ -113,7 +113,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_system_option_info.py
+++ b/plugins/modules/ovirt_system_option_info.py
@@ -100,7 +100,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_tag_info.py
+++ b/plugins/modules/ovirt_tag_info.py
@@ -125,7 +125,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_template_info.py
+++ b/plugins/modules/ovirt_template_info.py
@@ -102,7 +102,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_user_info.py
+++ b/plugins/modules/ovirt_user_info.py
@@ -98,7 +98,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_vm_info.py
+++ b/plugins/modules/ovirt_vm_info.py
@@ -150,7 +150,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_vm_os_info.py
+++ b/plugins/modules/ovirt_vm_os_info.py
@@ -110,7 +110,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_vmpool_info.py
+++ b/plugins/modules/ovirt_vmpool_info.py
@@ -100,7 +100,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:

--- a/plugins/modules/ovirt_vnic_profile_info.py
+++ b/plugins/modules/ovirt_vnic_profile_info.py
@@ -100,7 +100,7 @@ def main():
         module.deprecate(
             "The 'fetch_nested' and 'nested_attributes' are deprecated please use 'follow' parameter",
             version='3.0.0',
-            collection_name='ovirt.ovirt'
+            collection_name='@NAMESPACE@.@NAME@'
         )
 
     try:


### PR DESCRIPTION
Backport of https://github.com/oVirt/ovirt-ansible-collection/pull/653