### PR TITLE
roles: hosted_engine_setup: Delete also the bridge

### DIFF
--- a/changelogs/fragments/661-delete-also-the-bridge.yml
+++ b/changelogs/fragments/661-delete-also-the-bridge.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`, so we need to delete it expicitly (https://github.com/oVirt/ovirt-ansible-collection/pull/661).

--- a/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
+++ b/roles/hosted_engine_setup/tasks/alter_libvirt_default_net_configuration.yml
@@ -19,6 +19,11 @@
   ignore_errors: true
   changed_when: false
 
+- name: Update libvirt default network configuration, delete the bridge
+  ansible.builtin.command: ip link delete {{ network_dict['bridge']['name'] }}
+  ignore_errors: true
+  changed_when: false
+
 - name: Update libvirt default network configuration, undefine
   ansible.builtin.command: virsh net-undefine default
   ignore_errors: true


### PR DESCRIPTION
Recently CI CentOS Stream 9 fails on the following `virsh net-start default` saying that virbr0 already exists. Not sure why it's not deleted by `virsh net-destroy default` - perhaps that's a change in libvirt. Let's remove the bridge explicitly.

Signed-off-by: Yedidyah Bar David <didi@redhat.com>