### PR TITLE
Replace getargspec with getfullargspec

### DIFF
--- a/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
+++ b/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).

--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -280,7 +280,7 @@ def search_by_attributes(service, list_params=None, **kwargs):
     """
     list_params = list_params or {}
     # Check if 'list' method support search(look for search parameter):
-    if 'search' in inspect.getargspec(service.list)[0]:
+    if 'search' in inspect.getfullargspec(service.list)[0]:
         res = service.list(
             # There must be double quotes around name, because some oVirt resources it's possible to create then with space in name.
             search=' and '.join('{0}="{1}"'.format(k, v) for k, v in kwargs.items()),
@@ -308,7 +308,7 @@ def search_by_name(service, name, **kwargs):
     :return: Entity object returned by Python SDK
     """
     # Check if 'list' method support search(look for search parameter):
-    if 'search' in inspect.getargspec(service.list)[0]:
+    if 'search' in inspect.getfullargspec(service.list)[0]:
         res = service.list(
             # There must be double quotes around name, because some oVirt resources it's possible to create then with space in name.
             search='name="{name}"'.format(name=name)


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-collection/issues/659
The `getargspec` was supported in python 2 and removed in python 3.11.
The alternative is `getfullargspec`, which is in all python 3 versions.
