### PR TITLE
backport: Wait for host to be in result state (#621)

### DIFF
--- a/changelogs/fragments/667-wait-for-host-to-be-in-result-state.yml
+++ b/changelogs/fragments/667-wait-for-host-to-be-in-result-state.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/667)

--- a/plugins/modules/ovirt_host.py
+++ b/plugins/modules/ovirt_host.py
@@ -610,10 +610,12 @@ def main():
                 )
                 # Set to False, because upgrade_check isn't 'changing' action:
                 hosts_module._changed = False
+
+            updates_available = host.update_available
             ret = hosts_module.action(
                 action='upgrade',
                 action_condition=lambda h: h.update_available,
-                wait_condition=lambda h: not h.update_available or h.status == result_state and (
+                wait_condition=lambda h: h.status == result_state and ((
                     len([
                         event
                         for event in events_service.list(
@@ -625,7 +627,7 @@ def main():
                             search='type=842 or type=841 or type=888',
                         ) if host.name in event.description
                     ]) > 0
-                ),
+                ) or not updates_available),
                 post_action=lambda h: time.sleep(module.params['poll_interval']),
                 fail_condition=lambda h: hosts_module.failed_state_after_reinstall(h) or (
                     len([


### PR DESCRIPTION
* Wait for host to be in result state

Bug introduced in #580.
The update_available is false just after the upgrade, and
HOST_UPGRADE_FINISHED_AND_WILL_BE_REBOOTED is logged. But the host is
not yet rebooted, so we still need to wait for the status to be UP or
MAINTENANCE.

Signed-off-by: Martin Nečas <necas.marty@gmail.com>

* Fix wait_condition on host upgrade

In #580 we introduced a check on update_available state of the host to
determine if the host upgrade finished when there were no updates
available for te host.

The downside of this is that when the update finishes, the
update_available flag is cleared, and ansible thinks the host upgrade is
complete and starts upgrading the next node. But the reboot is not
completed yet, so result_state != h.status.

The fix here is to save the update_available status before starting the
update. If there were no updates and status hasn't changed, then it goes
on. If there was an update on the other hand, it will wait for the
HOST_UPGRADE_FAILED / HOST_UPGRADE_FINISHED /
HOST_UPGRADE_FINISHED_AND_WILL_BE_REBOOTED events.

Signed-off-by: Jean-Louis Dupond <jean-louis@dupond.be>
Signed-off-by: Martin Nečas <necas.marty@gmail.com>

Signed-off-by: Martin Nečas <necas.marty@gmail.com>
Signed-off-by: Jean-Louis Dupond <jean-louis@dupond.be>
Co-authored-by: Martin Nečas <necas.marty@gmail.com>