### PR TITLE
Release 2.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v2.4.2
+======
+
+Bugfixes
+--------
+
+- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
+- module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
+- ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/667)
+
 v2.4.1
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 VERSION="2.4.2"
-MILESTONE="master"
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+MILESTONE=""
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -895,3 +895,16 @@ releases:
     fragments:
     - 637-cluster_upgrade-fix-the-engine_correlation_id-location.yml
     release_date: '2022-11-28'
+  2.4.2:
+    changes:
+      bugfixes:
+      - info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation
+        warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
+      - module_utils - replace `getargspec` with `getfullargspec` to support newer
+        python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
+      - ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/667)
+    fragments:
+    - 653-info-modules-use-dynamic-name.yml
+    - 663-replace-getargspec-with-getfullargspec.yml
+    - 667-wait-for-host-to-be-in-result-state.yml
+    release_date: '2023-01-24'

--- a/changelogs/fragments/653-info-modules-use-dynamic-name.yml
+++ b/changelogs/fragments/653-info-modules-use-dynamic-name.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).

--- a/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
+++ b/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).

--- a/changelogs/fragments/667-wait-for-host-to-be-in-result-state.yml
+++ b/changelogs/fragments/667-wait-for-host-to-be-in-result-state.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/667)

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -87,6 +87,11 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Tue Jan 24 2023 Martin Necas <mnecas@redhat.com> - 2.4.2-1
+- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning
+- module_utils - Replace `getargspec` with `getfullargspec` to support newer python 3.y versions
+- ovirt_host - Wait for host to be in result state during upgrade
+
 * Mon Nov 28 2022 Martin Necas <mnecas@redhat.com> - 2.4.1-1
 - cluster_upgrade - Fix the engine_correlation_id location
 


### PR DESCRIPTION

v2.4.2
======

Bugfixes
--------

- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
- module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
- ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/667)