### PR TITLE
Python 3.11 has dropped support for getargspec

### DIFF
--- a/plugins/module_utils/ovirt.py
+++ b/plugins/module_utils/ovirt.py
@@ -25,6 +25,10 @@ import inspect
 import os
 import time
 
+# getargspec deprecation workaround
+if not hasattr(inspect, 'getargspec'):
+    inspect.getargspec = inspect.getfullargspec
+
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 


### PR DESCRIPTION
This is a temporary patch in case we still want to support older versions