### PR TITLE
Fix CI test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run ansible-lint 6.y.z
         run: |
           cd /tmp/ansible_collections/ovirt/ovirt/
-          pip3 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<7.0.0" cryptography
+          pip3.9 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<7.0.0" cryptography
           ansible-lint roles/* -x 204
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   sanity_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: ansible-test docker
     steps:
       - name: Checkout
@@ -26,10 +26,10 @@ jobs:
       - name: Run ansible-lint 6.y.z
         run: |
           cd /tmp/ansible_collections/ovirt/ovirt/
-          pip3.9 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<7.0.0" cryptography
+          pip3 install pycodestyle pylint voluptuous yamllint rstcheck antsibull-changelog rich "ansible-lint>=6.0.0,<7.0.0" cryptography
           ansible-lint roles/* -x 204
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/changelogs/fragments/677-remove-provision_docker-dependency.yml
+++ b/changelogs/fragments/677-remove-provision_docker-dependency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - engine_setup - Remove provision_docker from tests (https://github.com/oVirt/ovirt-ansible-collection/pull/677).

--- a/roles/engine_setup/tests/containers-deploy.yml
+++ b/roles/engine_setup/tests/containers-deploy.yml
@@ -1,11 +1,4 @@
 ---
-- name: Bring up docker containers
-  hosts: localhost
-  gather_facts: false
-  roles:
-    - role: provision_docker
-      provision_docker_inventory_group: "{{ groups['engine'] }}"
-
 - name: "Update python because of ovirt-imageio-proxy"
   hosts: engine
   tasks:

--- a/roles/engine_setup/tests/requirements.yml
+++ b/roles/engine_setup/tests/requirements.yml
@@ -1,4 +1,2 @@
 ---
-- src: chrismeyersfsu.provision_docker
-  name: provision_docker
 - src: oVirt.repositories


### PR DESCRIPTION
Issues:
- Downgrade ubuntu to 20.04 (there was an upgrade around new years to 22.04)
Latest ubuntu python version is 3.10 and the pip deps install fails with:
```
ERROR: Exception:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pip/_internal/cli/base_command.py", line 165, in exc_logging_wrapper
    status = run_func(*args)
  File "/usr/lib/python3/dist-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
    return func(self, options, args)
  File "/usr/lib/python3/dist-packages/pip/_internal/commands/install.py", line 389, in run
    to_install = resolver.get_installation_order(requirement_set)
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/resolver.py", line 188, in get_installation_order
    weights = get_topological_weights(
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/resolver.py", line 276, in get_topological_weights
    assert len(weights) == expected_node_count
AssertionError
```
- Remove provision_docker from the engine_setup test deps