### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,26 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v3.1.0
+======
+
+Minor Changes
+-------------
+
+- ovirt_host - Add refreshed state (https://github.com/oVirt/ovirt-ansible-collection/pull/673).
+- ovirt_network - Add default_route usage to the ovirt_network module (https://github.com/oVirt/ovirt-ansible-collection/pull/647).
+
+Bugfixes
+--------
+
+- engine_setup - Remove provision_docker from tests (https://github.com/oVirt/ovirt-ansible-collection/pull/677).
+- he-setup - Log the output sent to the serial console of the HostedEngineLocal VM to a file on the host, to allow diagnosing failures in that stage (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
+- he-setup - Run virt-install with options more suitable for debugging (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
+- he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`, so we need to delete it expicitly (https://github.com/oVirt/ovirt-ansible-collection/pull/661).
+- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
+- module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
+- ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/621)
+
 v3.0.0
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VERSION="3.0.1"
-MILESTONE="master"
-#MILESTONE=""
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
-#RPM_RELEASE="1"
+VERSION="3.1.0"
+# MILESTONE="master"
+MILESTONE=""
+# RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -895,3 +895,31 @@ releases:
     - 627-remove-warn-arg.yml
     - 637-cluster_upgrade-fix-the-engine_correlation_id-location.yml
     release_date: '2022-11-28'
+  3.1.0:
+    changes:
+      bugfixes:
+      - engine_setup - Remove provision_docker from tests (https://github.com/oVirt/ovirt-ansible-collection/pull/677).
+      - he-setup - Log the output sent to the serial console of the HostedEngineLocal
+        VM to a file on the host, to allow diagnosing failures in that stage (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
+      - he-setup - Run virt-install with options more suitable for debugging (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
+      - he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`,
+        so we need to delete it expicitly (https://github.com/oVirt/ovirt-ansible-collection/pull/661).
+      - info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation
+        warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
+      - module_utils - replace `getargspec` with `getfullargspec` to support newer
+        python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
+      - ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/621)
+      minor_changes:
+      - ovirt_host - Add refreshed state (https://github.com/oVirt/ovirt-ansible-collection/pull/673).
+      - ovirt_network - Add default_route usage to the ovirt_network module (https://github.com/oVirt/ovirt-ansible-collection/pull/647).
+    fragments:
+    - 621-wait-for-host-to-be-in-result-state.yml
+    - 647-add-default_route-usage-to-the-ovirt_network-module.yml
+    - 653-info-modules-use-dynamic-name.yml
+    - 661-delete-also-the-bridge.yml
+    - 663-replace-getargspec-with-getfullargspec.yml
+    - 664-debug-virt-install.yml
+    - 664-log-local-vm-console.yml
+    - 673-ovirt_host-add-refresh.yml
+    - 677-remove-provision_docker-dependency.yml
+    release_date: '2023-02-14'

--- a/changelogs/fragments/621-wait-for-host-to-be-in-result-state.yml
+++ b/changelogs/fragments/621-wait-for-host-to-be-in-result-state.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/621)

--- a/changelogs/fragments/647-add-default_route-usage-to-the-ovirt_network-module.yml
+++ b/changelogs/fragments/647-add-default_route-usage-to-the-ovirt_network-module.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - ovirt_network - Add default_route usage to the ovirt_network module (https://github.com/oVirt/ovirt-ansible-collection/pull/647).

--- a/changelogs/fragments/653-info-modules-use-dynamic-name.yml
+++ b/changelogs/fragments/653-info-modules-use-dynamic-name.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).

--- a/changelogs/fragments/661-delete-also-the-bridge.yml
+++ b/changelogs/fragments/661-delete-also-the-bridge.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`, so we need to delete it expicitly (https://github.com/oVirt/ovirt-ansible-collection/pull/661).

--- a/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
+++ b/changelogs/fragments/663-replace-getargspec-with-getfullargspec.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).

--- a/changelogs/fragments/664-debug-virt-install.yml
+++ b/changelogs/fragments/664-debug-virt-install.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - he-setup - Run virt-install with options more suitable for debugging (https://github.com/oVirt/ovirt-ansible-collection/pull/664).

--- a/changelogs/fragments/664-log-local-vm-console.yml
+++ b/changelogs/fragments/664-log-local-vm-console.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - he-setup - Log the output sent to the serial console of the HostedEngineLocal VM to a file on the host, to allow diagnosing failures in that stage (https://github.com/oVirt/ovirt-ansible-collection/pull/664).

--- a/changelogs/fragments/673-ovirt_host-add-refresh.yml
+++ b/changelogs/fragments/673-ovirt_host-add-refresh.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - ovirt_host - Add refreshed state (https://github.com/oVirt/ovirt-ansible-collection/pull/673).

--- a/changelogs/fragments/677-remove-provision_docker-dependency.yml
+++ b/changelogs/fragments/677-remove-provision_docker-dependency.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - engine_setup - Remove provision_docker from tests (https://github.com/oVirt/ovirt-ansible-collection/pull/677).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "@NAMESPACE@"
 name: "@NAME@"
-version: 3.0.1
+version: 3.1.0
 authors:
     - Martin Necas <mnecas@redhat.com>
 license:

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -87,6 +87,17 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Tue Feb 14 2023 Martin Necas <mnecas@redhat.com> - 3.1.0-1
+- ovirt_host - Add refreshed state.
+- ovirt_host - Wait for host to be in result state during upgrade.
+- ovirt_network - Add default_route usage to the ovirt_network module.
+- engine_setup - Remove provision_docker from tests.
+- he-setup - Log the output sent to the serial console of the HostedEngineLocal VM to a file on the host, to allow diagnosing failures in that stage.
+- he-setup - Run virt-install with options more suitable for debugging.
+- he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`, so we need to delete it expicitly.
+- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning.
+- module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions.
+
 * Mon Nov 28 2022 Martin Perina <mperina@redhat.com> - 3.0.0-1
 - filters: Fix ovirtvmipsv4 with attribute and network
 - ovirt_host: Fix kernel_params elemets


### PR DESCRIPTION

v3.1.0
======

Minor Changes
-------------

- ovirt_host - Add refreshed state (https://github.com/oVirt/ovirt-ansible-collection/pull/673).
- ovirt_network - Add default_route usage to the ovirt_network module (https://github.com/oVirt/ovirt-ansible-collection/pull/647).

Bugfixes
--------

- engine_setup - Remove provision_docker from tests (https://github.com/oVirt/ovirt-ansible-collection/pull/677).
- he-setup - Log the output sent to the serial console of the HostedEngineLocal VM to a file on the host, to allow diagnosing failures in that stage (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
- he-setup - Run virt-install with options more suitable for debugging (https://github.com/oVirt/ovirt-ansible-collection/pull/664).
- he-setup - recently `virsh net-destroy default` doesn't delete the `virbr0`, so we need to delete it expicitly (https://github.com/oVirt/ovirt-ansible-collection/pull/661).
- info modules - Use dynamic collection name instead of ovirt.ovirt for deprecation warning (https://github.com/oVirt/ovirt-ansible-collection/pull/653).
- module_utils - replace `getargspec` with `getfullargspec` to support newer python 3.y versions (https://github.com/oVirt/ovirt-ansible-collection/pull/663).
- ovirt_host - Wait for host to be in result state during upgrade (https://github.com/oVirt/ovirt-ansible-collection/pull/621)
