### PR TITLE
[WIP] Don't skip validate-modules and pylint

### DIFF
--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -10,4 +10,3 @@ roles/disaster_recovery/files/generate_vars_test.py shebang!skip
 roles/disaster_recovery/files/validator.py shebang!skip
 roles/disaster_recovery/files/vault_secret.sh shellcheck!skip
 roles/disaster_recovery/files/ovirt-dr shebang!skip
-plugins/module_utils/cloud.py pylint!skip

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,8 +1,6 @@
 build.sh shebang!skip
 changelogs/fragments/.keep changelog!skip
 plugins/callback/stdout.py shebang!skip
-plugins/callback/stdout.py validate-modules!skip
-plugins/inventory/ovirt.py validate-modules!skip
 roles/disaster_recovery/files/fail_back.py shebang!skip
 roles/disaster_recovery/files/bcolors.py shebang!skip
 roles/disaster_recovery/files/fail_over.py shebang!skip
@@ -12,4 +10,3 @@ roles/disaster_recovery/files/generate_vars_test.py shebang!skip
 roles/disaster_recovery/files/validator.py shebang!skip
 roles/disaster_recovery/files/vault_secret.sh shellcheck!skip
 roles/disaster_recovery/files/ovirt-dr shebang!skip
-plugins/module_utils/cloud.py pylint!skip

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,7 +1,5 @@
 build.sh shebang!skip
 plugins/callback/stdout.py shebang!skip
-plugins/callback/stdout.py validate-modules!skip
-plugins/inventory/ovirt.py validate-modules!skip
 roles/disaster_recovery/files/fail_back.py shebang!skip
 roles/disaster_recovery/files/bcolors.py shebang!skip
 roles/disaster_recovery/files/fail_over.py shebang!skip
@@ -11,4 +9,3 @@ roles/disaster_recovery/files/generate_vars_test.py shebang!skip
 roles/disaster_recovery/files/validator.py shebang!skip
 roles/disaster_recovery/files/vault_secret.sh shellcheck!skip
 roles/disaster_recovery/files/ovirt-dr shebang!skip
-plugins/module_utils/cloud.py pylint!skip


### PR DESCRIPTION
Don't skip validate-modules and pylint checks for following modules:

- plugins/callback/stdout.py
- plugins/inventory/ovirt.py
- plugins/module_utils/cloud.py

Signed-off-by: Martin Perina <mperina@redhat.com>
