### PR TITLE
roles: hosted_engine_setup: Adding the -n flag to qemu-img command

### DIFF
--- a/changelogs/fragments/682-hosted_engine_setup-fix-disk-copying-command.yml
+++ b/changelogs/fragments/682-hosted_engine_setup-fix-disk-copying-command.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - hosted_engine_setup - Vdsm now uses -n flag for all qemu-img convert calls (https://github.com/oVirt/ovirt-ansible-collection/pull/682).

--- a/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/roles/hosted_engine_setup/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -275,7 +275,7 @@
       changed_when: true
     - name: Copy local VM disk to shared storage
       ansible.builtin.command: >-
-        qemu-img convert -f qcow2 -O raw -t none -T none {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
+        qemu-img convert -n -f qcow2 -O raw -t none -T none {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
       environment: "{{ he_cmd_lang }}"
       become: true
       become_user: vdsm


### PR DESCRIPTION
Issues:

1. Desired Engine Disk size for hosted engine VM is not reflected and always 38GB.

Fix:

1. Adding the -n flag to use the same flags used by vdsm to ensure that we get consistent results compatible with volumes created by vdsm. Vdsm now uses -n flag for all qemu-img convert calls "https://gerrit.ovirt.org/c/vdsm/+/109784". 
https://bugzilla.redhat.com/show_bug.cgi?id=1828888#c5

Signed-off-by: Saksham Srivastava saksham.sa.srivastava@oracle.com