### PR TITLE
spec: Add python3.11 requirements

### DIFF
--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -18,15 +18,18 @@ BuildRequires:	glibc-langpack-en
 %endif
 
 Requires:	ansible-core >= 2.13.0
-Requires:	ovirt-imageio-client
-Requires:	python3-ovirt-engine-sdk4 >= 4.5.0
-Requires:	python3-netaddr
-Requires:	python3-jmespath
-Requires:	python3-passlib
 Requires:	ansible-collection-ansible-netcommon
 Requires:	ansible-collection-ansible-posix
 Requires:	ansible-collection-ansible-utils
 Requires:	qemu-img
+
+%if 0%{?rhel} >= 9
+Requires:	python3.11-ovirt-imageio-client
+Requires:	python3.11-ovirt-engine-sdk4 >= 4.5.0
+Requires:	python3.11-netaddr
+Requires:	python3.11-jmespath
+Requires:	python3.11-passlib
+%endif
 
 %if 0%{?rhel} < 9
 Requires:	python39-ovirt-imageio-client


### PR DESCRIPTION
The ansible-core 2.14 uses python3.11 on Centos 9 stream instead of the default system python3.9. We need to build the rpm to use the collection with the ansible-core 2.14, which forces the python library to python3.11 so the ansible can use the collection.