### PR TITLE
we need python3-jmespath for ansible runs with platform python

### DIFF
--- a/changelogs/fragments/701-fix-jmespath.yml
+++ b/changelogs/fragments/701-fix-jmespath.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+      - HE - add back dependency on python3-jmespath (https://github.com/oVirt/ovirt-ansible-collection/pull/701)

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -22,6 +22,7 @@ Requires:	ansible-collection-ansible-netcommon
 Requires:	ansible-collection-ansible-posix
 Requires:	ansible-collection-ansible-utils
 Requires:	qemu-img
+Requires:   python3-jmespath
 
 %if 0%{?rhel} >= 9
 Requires:	python3.11-ovirt-imageio-client


### PR DESCRIPTION
hosted-engine-setup runs with platform-python and requires jmespath
