### PR TITLE
Support boot disk renaming and resizing.

### DIFF
--- a/changelogs/fragments/705-support-boot-disk-resizing-renaming.yml
+++ b/changelogs/fragments/705-support-boot-disk-resizing-renaming.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+      - vm_infra - Support boot disk renaming and resizing. (https://github.com/oVirt/ovirt-ansible-collection/pull/705)

--- a/roles/vm_infra/README.md
+++ b/roles/vm_infra/README.md
@@ -66,6 +66,9 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | clone              | No                    | If yes then the disks of the created virtual machine will be cloned and independent of the template.  This parameter is used only when state is running or present and VM didn't exist before.  |
 | template           | Blank                 | Name of template that the virtual machine should be based on.   |
 | template_version   | UNDEF                 | Version number of the template to be used for VM. By default the latest available version of the template is used.   |
+| boot_disk_name     | UNDEF                 | Renames the bootable disk after the VM is created. Useful when creating VMs from templates |
+| boot_disk_use_vm_name_prefix | true        | Use the name of the virtual machine as prefix when renaming the VM boot disk. The resulting boot disk name would be <i>{{vm_name}}_{{boot_disk_name}}</i>|
+| boot_disk_size     | UNDEF                 | Resizes the bootable disk after the VM is created. A suffix that complies to the IEC 60027-2 standard (for example 10GiB, 1024MiB) can be used. |
 | memory             | UNDEF                 | Amount of virtual machine memory.               |
 | memory_max         | UNDEF                 | Upper bound of virtual machine memory up to which memory hot-plug can be performed. |
 | memory_guaranteed  | UNDEF                 | Amount of minimal guaranteed memory of the Virtual Machine. Prefix uses IEC 60027-2 standard (for example 1GiB, 1024MiB). <i>memory_guaranteed</i> parameter can't be lower than <i>memory</i> parameter. |

--- a/roles/vm_infra/tasks/rename_resize_boot_disk.yml
+++ b/roles/vm_infra/tasks/rename_resize_boot_disk.yml
@@ -1,0 +1,59 @@
+---
+- name: "Get the '{{ current_vm.name }}' VM info"
+  ovirt_vm_info:
+    auth: "{{ ovirt_auth }}"
+    pattern: "name={{ current_vm.name }}"
+    fetch_nested: true
+    nested_attributes:
+      - "bootable"
+    all_content: true
+  register: current_vm_info
+
+- name: "Get the '{{ current_vm.name }}' VM boot disk ID"
+  ansible.builtin.set_fact:
+    current_vm_boot_disk_id: "{{ item.id }}"
+  loop: "{{ current_vm_info.ovirt_vms[0].disk_attachments }} "
+  when: item.bootable is defined and item.bootable
+
+- name: "Get the '{{ current_vm.name }}' VM boot disk info"
+  ovirt_disk_info:
+    auth: "{{ ovirt_auth }}"
+    pattern: "id={{ current_vm_boot_disk_id }}"
+    fetch_nested: true
+  register: current_vm_boot_disk_info
+  when: current_vm_boot_disk_id is defined
+
+- name: "Get the Storage Domain info from the '{{ current_vm.name }}' VM boot disk"
+  ovirt_storage_domain:
+    auth: "{{ ovirt_auth }}"
+    id: "{{ current_vm_boot_disk_info.ovirt_disks[0].storage_domains[0].id }}"
+  register: current_vm_boot_disk_sd_info
+  when: current_vm_boot_disk_id is defined
+
+- name: "Get the '{{ current_vm.name }}' VM boot disk name"
+  ansible.builtin.set_fact:
+    current_vm_boot_disk_name: "{{ current_vm.boot_disk_name | default(current_vm.profile.boot_disk_name) }}"
+  when: current_vm.boot_disk_name is defined or current_vm.profile.boot_disk_name is defined
+
+- name: "Use '{{ current_vm.name }}' as prefix for the VM boot disk name"
+  ansible.builtin.set_fact:
+    current_vm_boot_disk_use_vm_name_prefix: >
+      "{{ current_vm.boot_disk_use_vm_name_prefix | default(current_vm.profile.boot_disk_use_vm_name_prefix) | default(true) }}"
+
+- name: "Rename the '{{ current_vm.name }}' VM boot disk"
+  ovirt_disk:
+    auth: "{{ ovirt_auth }}"
+    id: "{{ current_vm_boot_disk_id }}"
+    name: "{% if current_vm_boot_disk_use_vm_name_prefix %}{{ current_vm.name }}_{% endif %}{{ current_vm_boot_disk_name }}"
+    vm_name: "{{ current_vm.name }}"
+    storage_domain: "{{ current_vm_boot_disk_sd_info.storagedomain.name }}"
+  when: current_vm_boot_disk_id is defined and current_vm_boot_disk_name is defined
+
+- name: "Resize the '{{ current_vm.name }}' VM boot disk"
+  ovirt_disk:
+    auth: "{{ ovirt_auth }}"
+    id: "{{ current_vm_boot_disk_id }}"
+    size: "{{ current_vm.boot_disk_size | default(current_vm.profile.boot_disk_size) }}"
+    vm_name: "{{ current_vm.name }}"
+  when: ( current_vm.boot_disk_size is defined or current_vm.profile.boot_disk_size is defined ) and current_vm_boot_disk_id is defined
+...

--- a/roles/vm_infra/tasks/vm_state_present.yml
+++ b/roles/vm_infra/tasks/vm_state_present.yml
@@ -20,6 +20,12 @@
 - name: Apply any Affinity Labels
   import_tasks: affinity_labels.yml
 
+- name: Rename and resize boot disk
+  include_tasks: rename_resize_boot_disk.yml
+  with_items: "{{ create_vms }}"
+  loop_control:
+    loop_var: "current_vm"
+
 - name: Manage profile disks
   ovirt_disk:
     auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
Renames the boot disk when the `boot_disk_name` variable is defined
within the profile or the VM properties. (The latter has precedence
over the former). The VM disk must have the bootable flag set.

By default, if `boot_disk_name` is defined, the VM name will be
prepended to the boot disk name so the final name would be:

`{{ vm_name }}_{{ boot_disk_name }}`

This behavior can be disabled by setting the variable
`boot_disk_use_vm_name_prefix` to `false`. In this case the
final name of the boot disk will be the value of `boot_disk_name`.

The boot disk can also be resized by defining the `boot_disk_size`
variable.

The value can contain a suffix that complies to the IEC 60027-2
standard (for example 10GiB, 1024MiB)

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
