### PR TITLE
ovirt_disk: Fix issue in detaching the direct LUN

### DIFF
--- a/.automation/build.sh
+++ b/.automation/build.sh
@@ -67,7 +67,8 @@ cp -r "$OVIRT_BUILD"/* "$OVIRT_BUILD"/.config "$COLLECTION_DIR"
 cd "$COLLECTION_DIR"
 
 antsibull-changelog lint -v
-ansible-lint roles/*
+# dropping linter in favor of "ansible-test docker" github action
+#ansible-lint roles/*
 
 cd "$ROOT_PATH"
 

--- a/changelogs/fragments/700-fix-directlun.yml
+++ b/changelogs/fragments/700-fix-directlun.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+      - ovirt_disk -  Fix issue in detaching the direct LUN (https://github.com/oVirt/ovirt-ansible-collection/pull/700)

--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -736,7 +736,7 @@ class DisksModule(BaseModule):
             equal(self.param('propagate_errors'), entity.propagate_errors) and
             equal(otypes.ScsiGenericIO(self.param('scsi_passthrough')) if self.param('scsi_passthrough') else None, entity.sgio) and
             equal(self.param('wipe_after_delete'), entity.wipe_after_delete) and
-            equal(self.param('profile'), follow_link(self._connection, entity.disk_profile).name)
+            equal(self.param('profile'), getattr(follow_link(self._connection, entity.disk_profile), 'name', None))
         )
 
 


### PR DESCRIPTION
The direct LUN doesn't have a disk profile and follow_link(self._connection, entity.disk_profile
) will be None. So detaching the LUN will fail with error "'NoneType' object has no attribute 'name'".

Signed-off-by: Nijin Ashok <nashok@redhat.com>
