### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v3.1.3
+======
+
+Bugfixes
+--------
+
+- HE - add back dependency on python3-jmespath (https://github.com/oVirt/ovirt-ansible-collection/pull/701)
+- HE - drop remaining filters using netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/702)
+- HE - drop usage of ipaddr filters and remove dependency on python-netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/696)
+- HE - fix ipv4 and ipv6 check after dropping netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/704)
+- hosted_engine_setup -  Update README (https://github.com/oVirt/ovirt-ansible-collection/pull/706)
+- ovirt_disk -  Fix issue in detaching the direct LUN (https://github.com/oVirt/ovirt-ansible-collection/pull/700)
+- ovirt_quota - Convert storage size to integer (https://github.com/oVirt/ovirt-ansible-collection/pull/712)
+
 v3.1.1
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 VERSION="3.1.3"
-MILESTONE="master"
-# MILESTONE=""
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
-# RPM_RELEASE="1"
+# MILESTONE="master"
+MILESTONE=""
+# RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -935,3 +935,23 @@ releases:
     - 684-ovirt_cluster_info-fix-example-patter.yml
     - 687-ovirt_host-fix-refreshed-state-action.yml
     release_date: '2023-03-03'
+  3.1.3:
+    changes:
+      bugfixes:
+      - HE - add back dependency on python3-jmespath (https://github.com/oVirt/ovirt-ansible-collection/pull/701)
+      - HE - drop remaining filters using netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/702)
+      - HE - drop usage of ipaddr filters and remove dependency on python-netaddr
+        (https://github.com/oVirt/ovirt-ansible-collection/pull/696)
+      - HE - fix ipv4 and ipv6 check after dropping netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/704)
+      - hosted_engine_setup -  Update README (https://github.com/oVirt/ovirt-ansible-collection/pull/706)
+      - ovirt_disk -  Fix issue in detaching the direct LUN (https://github.com/oVirt/ovirt-ansible-collection/pull/700)
+      - ovirt_quota - Convert storage size to integer (https://github.com/oVirt/ovirt-ansible-collection/pull/712)
+    fragments:
+    - 696-drop-netaddr.yml
+    - 700-fix-directlun.yml
+    - 701-fix-jmespath.yml
+    - 702-drop-netaddr2.yml
+    - 704-drop-netaddr3.yml
+    - 706-he-update-README.yml
+    - 712-ovirt_quota-fix-storage-size-typecast.yml
+    release_date: '2023-08-23'

--- a/changelogs/fragments/696-drop-netaddr.yml
+++ b/changelogs/fragments/696-drop-netaddr.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-    - HE - drop usage of ipaddr filters and remove dependency on python-netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/696)

--- a/changelogs/fragments/700-fix-directlun.yml
+++ b/changelogs/fragments/700-fix-directlun.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-      - ovirt_disk -  Fix issue in detaching the direct LUN (https://github.com/oVirt/ovirt-ansible-collection/pull/700)

--- a/changelogs/fragments/701-fix-jmespath.yml
+++ b/changelogs/fragments/701-fix-jmespath.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-      - HE - add back dependency on python3-jmespath (https://github.com/oVirt/ovirt-ansible-collection/pull/701)

--- a/changelogs/fragments/702-drop-netaddr2.yml
+++ b/changelogs/fragments/702-drop-netaddr2.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-      - HE - drop remaining filters using netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/702)

--- a/changelogs/fragments/704-drop-netaddr3.yml
+++ b/changelogs/fragments/704-drop-netaddr3.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-          - HE - fix ipv4 and ipv6 check after dropping netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/704)

--- a/changelogs/fragments/706-he-update-README.yml
+++ b/changelogs/fragments/706-he-update-README.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-      - hosted_engine_setup -  Update README (https://github.com/oVirt/ovirt-ansible-collection/pull/706)

--- a/changelogs/fragments/712-ovirt_quota-fix-storage-size-typecast.yml
+++ b/changelogs/fragments/712-ovirt_quota-fix-storage-size-typecast.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-      - ovirt_quota - Convert storage size to integer (https://github.com/oVirt/ovirt-ansible-collection/pull/712)

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -89,6 +89,15 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Wed Aug 23 2023 Martin Necas <mnecas@redhat.com> - 3.1.3-1
+- HE - add back dependency on python3-jmespath
+- HE - drop remaining filters using netaddr
+- HE - drop usage of ipaddr filters and remove dependency on python-netaddr
+- HE - fix ipv4 and ipv6 check after dropping netaddr
+- hosted_engine_setup -  Update README
+- ovirt_disk -  Fix issue in detaching the direct LUN
+- ovirt_quota - Convert storage size to integer
+
 * Thu Mar 23 2023 Martin Necas <mnecas@redhat.com> - 3.1.2-1
 - Add Python 3.11 subpackage to be usable in ansible-core 2.14 for el8
 


### PR DESCRIPTION

v3.1.3
======

Bugfixes
--------

- HE - add back dependency on python3-jmespath (https://github.com/oVirt/ovirt-ansible-collection/pull/701)
- HE - drop remaining filters using netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/702)
- HE - drop usage of ipaddr filters and remove dependency on python-netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/696)
- HE - fix ipv4 and ipv6 check after dropping netaddr (https://github.com/oVirt/ovirt-ansible-collection/pull/704)
- hosted_engine_setup -  Update README (https://github.com/oVirt/ovirt-ansible-collection/pull/706)
- ovirt_disk -  Fix issue in detaching the direct LUN (https://github.com/oVirt/ovirt-ansible-collection/pull/700)
- ovirt_quota - Convert storage size to integer (https://github.com/oVirt/ovirt-ansible-collection/pull/712)