### PR TITLE
ovirt_role: Fix administrative option when set to False

### DIFF
--- a/changelogs/fragments/723-ovirt_role-fix-administrative-condition.yml
+++ b/changelogs/fragments/723-ovirt_role-fix-administrative-condition.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+      - ovirt_role - Fix administrative option when set to False (https://github.com/oVirt/ovirt-ansible-collection/pull/723).

--- a/plugins/modules/ovirt_role.py
+++ b/plugins/modules/ovirt_role.py
@@ -112,8 +112,7 @@ class RoleModule(BaseModule):
         return otypes.Role(
             id=self.param('id'),
             name=self.param('name'),
-            administrative=self.param('administrative') if self.param(
-                'administrative') else None,
+            administrative=self.param('administrative') if self.param('administrative') is not None else None,
             permits=[
                 otypes.Permit(id=all_permits.get(new_permit)) for new_permit in self.param('permits')
             ] if self.param('permits') else None,


### PR DESCRIPTION
When user set administrative to false the option was not set and API failed with 400.