### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ ovirt.ovirt Release Notes
 .. contents:: Topics
 
 
+v3.2.0
+======
+
+Minor Changes
+-------------
+
+- ovirt_vm - Add tpm_enabled (https://github.com/oVirt/ovirt-ansible-collection/pull/722).
+- storage_error_resume_behaviour - Support VM storage error resume behaviour "auto_resume", "kill", "leave_paused". (https://github.com/oVirt/ovirt-ansible-collection/pull/721)
+- vm_infra - Support boot disk renaming and resizing. (https://github.com/oVirt/ovirt-ansible-collection/pull/705)
+
+Bugfixes
+--------
+
+- ovirt_role - Fix administrative option when set to False (https://github.com/oVirt/ovirt-ansible-collection/pull/723).
+
 v3.1.3
 ======
 

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VERSION="3.1.4"
-MILESTONE="master"
-# MILESTONE=""
-RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
-# RPM_RELEASE="1"
+VERSION="3.2.0"
+# MILESTONE="master"
+MILESTONE=""
+# RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
+RPM_RELEASE="1"
 
 BUILD_TYPE=$2
 BUILD_PATH=$3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -955,3 +955,18 @@ releases:
     - 706-he-update-README.yml
     - 712-ovirt_quota-fix-storage-size-typecast.yml
     release_date: '2023-08-23'
+  3.1.4:
+    changes:
+      bugfixes:
+      - ovirt_role - Fix administrative option when set to False (https://github.com/oVirt/ovirt-ansible-collection/pull/723).
+      minor_changes:
+      - ovirt_vm - Add tpm_enabled (https://github.com/oVirt/ovirt-ansible-collection/pull/722).
+      - storage_error_resume_behaviour - Support VM storage error resume behaviour
+        "auto_resume", "kill", "leave_paused". (https://github.com/oVirt/ovirt-ansible-collection/pull/721)
+      - vm_infra - Support boot disk renaming and resizing. (https://github.com/oVirt/ovirt-ansible-collection/pull/705)
+    fragments:
+    - 705-support-boot-disk-resizing-renaming.yml
+    - 721-enhancement-vm-storage-error-resume-behaviour.yml
+    - 722-add-tpm-enabled.yml
+    - 723-ovirt_role-fix-administrative-condition.yml
+    release_date: '2023-10-02'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "@NAMESPACE@"
 name: "@NAME@"
-version: 3.1.4
+version: 3.2.0
 authors:
     - Martin Necas <mnecas@redhat.com>
 license:

--- a/ovirt-ansible-collection.spec.in
+++ b/ovirt-ansible-collection.spec.in
@@ -89,6 +89,12 @@ sh build.sh install %{collectionname}
 %license licenses
 
 %changelog
+* Mon Oct 2 2023 Martin Necas <mnecas@redhat.com> - 3.2.0-1
+- ovirt_vm - Add tpm_enabled
+- storage_error_resume_behaviour - Support VM storage error resume behaviour "auto_resume", "kill", "leave_paused"
+- vm_infra - Support boot disk renaming and resizing
+- ovirt_role - Fix administrative option when set to False
+
 * Wed Aug 23 2023 Martin Necas <mnecas@redhat.com> - 3.1.3-1
 - HE - add back dependency on python3-jmespath
 - HE - drop remaining filters using netaddr


### PR DESCRIPTION
v3.2.0
======

Minor Changes
-------------

- ovirt_vm - Add tpm_enabled by @mmartinv (https://github.com/oVirt/ovirt-ansible-collection/pull/722).
- storage_error_resume_behaviour - Support VM storage error resume behaviour "auto_resume", "kill", "leave_paused" by @hemak88 (https://github.com/oVirt/ovirt-ansible-collection/pull/721)
- vm_infra - Support boot disk renaming and resizing by @mmartinv (https://github.com/oVirt/ovirt-ansible-collection/pull/705)

Bugfixes
--------

- ovirt_role - Fix administrative option when set to False by @mnecas  (https://github.com/oVirt/ovirt-ansible-collection/pull/723).