### PR TITLE
Not possible to attach LUN to running VM through ansible

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -843,7 +843,7 @@ def main():
     host = module.params['host']
     # Fail when host is specified with the LUN id. LUN id is needed to identify
     # an existing disk if already available in the environment.
-    if (host and lun is None) or (host and lun.get("id") is None):
+    if (host and lun is None) or (host and lun.get("lun_id") is None):
         module.fail_json(
             msg="Can not use parameter host ({0!s}) without "
             "specifying the logical_unit id".format(host)
@@ -866,7 +866,7 @@ def main():
         force_create = False
         vm_service = get_vm_service(connection, module)
         if lun:
-            disk = _search_by_lun(disks_service, lun.get('id'))
+            disk = _search_by_lun(disks_service, lun.get('lun_id'))
         else:
             disk = disks_module.search_entity(search_params=searchable_attributes(module))
             if vm_service and disk and state != 'attached':


### PR DESCRIPTION
Issue: Ansible example shows that lun can be attached to vm. The example shows to add lun with lun_id and storage_type attribute. The ansibles scripts fails to execute as it fails to attach disk because it failed to find the lun and associated disk info. The issue was the lun directory structure has lun_id attribute and the lookup code was using just id instead of lun_id.

https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_disk_module.html#parameter-logical_unit/lun_id

Fix: Fix the attribute name that used to get the disk info.

Signed-off-by: Saksham Srivastava <saksham.sa.srivastava@oracle.com>
