### PR TITLE
Revert "image_template: enable image template version name"

### DIFF
--- a/changelogs/fragments/733-enable-image-template-version-name.yml
+++ b/changelogs/fragments/733-enable-image-template-version-name.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-      - image_template - Support `template_version_name`, `template_description` and `template_operative_system`. (https://github.com/oVirt/ovirt-ansible-collection/pull/733)

--- a/roles/image_template/README.md
+++ b/roles/image_template/README.md
@@ -49,9 +49,6 @@ Role Variables
 | glance_image_provider        | UNDEF (mandatory if qcow_url is not used)            | Name of the glance image provider.                    |
 | glance_image            | UNDEF (mandatory if qcow_url is not used)               | This parameter specifies the name of disk in glance provider to be imported as template. |
 | template_prerequisites_tasks | UNDEF | Works only with qcow image. Specify a path to Ansible tasks file, which should be executed on virtual machine before creating a template from it. Note that qcow image must contain guest agent which reports IP address. |
-| template_version_name      | "base version" | Version name of the template. Allows to create different versions of a template.  |
-| template_description       | UNDEF | Sets the template description |
-| template_operating_system  | UNDEF | Sets the template Operative System |
 
 The `template_disks` List of dictionaries can contain following attributes:
 

--- a/roles/image_template/defaults/main.yml
+++ b/roles/image_template/defaults/main.yml
@@ -16,7 +16,6 @@ template_nics:
     profile_name: ovirtmgmt
     interface: virtio
 template_seal: true
-template_version_name: "base version"
 
 disk_resize_timeout: 60
 disk_storage_domain: null

--- a/roles/image_template/tasks/qcow2_image.yml
+++ b/roles/image_template/tasks/qcow2_image.yml
@@ -83,8 +83,7 @@
     - name: Check if template already exists
       ovirt_template_info:
         auth: "{{ ovirt_auth }}"
-        pattern: "name={{ template_name }} and datacenter={{ dc_info.ovirt_datacenters[0].name }}
-          and version_name=\"{{ template_version_name }}\""
+        pattern: "name={{ template_name }} and datacenter={{ dc_info.ovirt_datacenters[0].name }}"
       register: template_info
       tags:
         - ovirt-template-image
@@ -231,10 +230,6 @@
         cluster: "{{ template_cluster }}"
         timeout: "{{ template_timeout }}"
         seal: "{{ template_seal }}"
-        version:
-          name: "{{ template_version_name }}"
-        description: "{{ template_description | default(omit)}}"
-        operating_system: "{{ template_operating_system | default(omit)}}"
       when: template_info.ovirt_templates | length == 0
       tags:
         - ovirt-template-image


### PR DESCRIPTION
With this PR OST fails when creating template with following error:

```
'"Incomplete parameters". Fault detail is '
                                  '"TemplateVersion [baseTemplate] required '
                                  'for addFromVm". HTTP response code is '
                                  '400.
```

Please repost the change once you verify that the change doesn't break OST.

Reverts oVirt/ovirt-ansible-collection#733