### PR TITLE
ovirt_disk: Fix documentation of logical unit id

### DIFF
--- a/plugins/modules/ovirt_disk.py
+++ b/plugins/modules/ovirt_disk.py
@@ -157,7 +157,7 @@ options:
             target:
                 description:
                     - iSCSI target.
-            lun_id:
+            id:
                 description:
                     - LUN id.
             username:


### PR DESCRIPTION
ovirt_disk update documentation of logical unit id from lun_id to id to allying with the code

Continuation of: https://github.com/oVirt/ovirt-ansible-collection/pull/736