### PR TITLE
Issue: On the SHE host ovirt-ha-agent logs are filled with mail notification errors

### DIFF
--- a/changelogs/fragments/741-enable-and-start-postfix-service.yml
+++ b/changelogs/fragments/741-enable-and-start-postfix-service.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - Enable and start postfix service so that ovirt-ha-agent logs are not filled with mail notification errors (https://github.com/oVirt/ovirt-ansible-collection/pull/741)

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -217,6 +217,14 @@
       register: host_result_up_check
       ignore_errors: true
 
+    - name: Enable postfix service
+      ansible.builtin.service:
+        name: postfix
+        enabled: yes
+        state: started
+      register: postfix_service_status
+      ignore_errors: true
+
     - name: Handle deployment failure
       block:
         - name: Set host_id

--- a/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/roles/hosted_engine_setup/tasks/bootstrap_local_vm/05_add_host.yml
@@ -220,7 +220,7 @@
     - name: Enable postfix service
       ansible.builtin.service:
         name: postfix
-        enabled: yes
+        enabled: true
         state: started
       register: postfix_service_status
       ignore_errors: true


### PR DESCRIPTION
Issue:
On the SHE host ovirt-ha-agent logs are filled with mail notification errors

Fix:
Add an ansible task to enable and start postfix service on SHE hosts

Testing Done:
Created local yml file to enable and start postfix service. Verified that tasks start the service.


Signed-off-by: ShubhaOracle <Shubha.kulkarni@oracle.com>
