### PR TITLE
build: add safe.directory to fix CI build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,7 @@ build() {
     BUILD_PATH="$BUILD_PATH/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME/"
     mkdir -p "$BUILD_PATH"
     echo "Copying files to $BUILD_PATH"
+    git config --global --add safe.directory $(pwd)
     git archive --format=tar HEAD | (cd "$BUILD_PATH" && tar xf -)
     cd "$BUILD_PATH"
     rename


### PR DESCRIPTION
This should fix the following CI error:
fatal: detected dubious ownership in repository at '/__w/ovirt-ansible-collection/ovirt-ansible-collection' To add an exception for this directory, call:

	git config --global --add safe.directory /__w/ovirt-ansible-collection/ovirt-ansible-collection
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors