### PR TITLE
lint: fix lint errors

### DIFF
--- a/changelogs/fragments/771-fix-lint.yaml
+++ b/changelogs/fragments/771-fix-lint.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix linting issues `(can only concatenate list (not "UndefinedMarker") to list)` (https://github.com/oVirt/ovirt-ansible-collection/pull/771)

--- a/roles/cluster_upgrade/tasks/main.yml
+++ b/roles/cluster_upgrade/tasks/main.yml
@@ -138,11 +138,11 @@
 
         - name: Build the list of hosts that will be upgraded (hosts in host_info.ovirt_hosts hosts w/o pinned vms that cannot be stopped)
           ansible.builtin.set_fact:
-            good_hosts: "{{ (good_hosts | default([])) | list + [ host ] | list }}"
+            good_hosts: "{{ (good_hosts | default([])) + [ host ] }}"
           loop: "{{ host_info.ovirt_hosts | flatten(levels=1) }}"
           loop_control:
             loop_var: "host"
-          when: "host.id not in host_ids or stop_non_migratable_vms"
+          when: "host.id not in (host_ids | default([])) or stop_non_migratable_vms"
 
         - name: progress 8% - log hosts that will be upgraded
           ansible.builtin.include_tasks: log_progress.yml

--- a/roles/disaster_recovery/tasks/recover/register_vms.yml
+++ b/roles/disaster_recovery/tasks/recover/register_vms.yml
@@ -15,7 +15,7 @@
 
     - name: Set unregistered VMs
       ansible.builtin.set_fact:
-        unreg_vms: "{{ unreg_vms | default([]) + storage_vm_info.ovirt_storage_vms }}"
+        unreg_vms: "{{ (unreg_vms | default([])) + (storage_vm_info.ovirt_storage_vms | default([])) }}"
 
     # TODO: We should filter out VMs which already exist in the setup (diskless VMs)
     - name: Register VMs


### PR DESCRIPTION
Fixes the error:
```
Error: Error rendering template: can only concatenate list (not
"UndefinedMarker") to list
```