### PR TITLE
core: remove RHV references from engine_setup role

### DIFF
--- a/changelogs/fragments/779-remove-rhv.yaml
+++ b/changelogs/fragments/779-remove-rhv.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Remove product type in engine_setup role as Red Hat Virtualization is no longer supported (https://github.com/oVirt/ovirt-ansible-collection/pull/779)

--- a/roles/engine_setup/README.md
+++ b/roles/engine_setup/README.md
@@ -20,7 +20,6 @@ to ``ovirt_engine_setup_answer_file_path`` variable.
 | ovirt_engine_setup_use_remote_answer_file | False             | If `True`, use answerfile's path on the remote machine. This option should be used if the installation occurs on the remote machine and the answerfile is located there as well. |
 | ovirt_engine_setup_update_setup_packages | False              | If `True`, setup packages will be updated before `engine-setup` is executed. It makes sense if Engine has already been installed. |
 | ovirt_engine_setup_perform_upgrade    | False                 | If `True`, this role is used to perform an upgrade. |
-| ovirt_engine_setup_product_type       | oVirt                 | One of ["oVirt", "RHV"], case insensitive. |
 | ovirt_engine_setup_offline            | False                 | If `True`, updates for all packages will be disabled. |
 | ovirt_engine_setup_restore_engine_cleanup | False             | Remove the configuration files and clean the database associated with the Engine, relevant only when `ovirt_engine_setup_restore_file` is defined |
 | ovirt_engine_setup_restore_file       | UNDEF                 | Restored the engine with a backup file which created with engine-backup. |
@@ -102,22 +101,6 @@ Example Playbook
   vars:
     ovirt_engine_setup_version: '4.5'
     ovirt_engine_setup_organization: 'of.ovirt.engine.com'
-  roles:
-    - engine_setup
-  collections:
-    - ovirt.ovirt
-
-
-# Example of RHV setup:
-- name: Setup RHV
-  hosts: engine
-  vars_files:
-    # Contains encrypted `ovirt_engine_setup_admin_password` variable using ansible-vault
-    - passwords.yml
-  vars:
-    ovirt_engine_setup_version: '4.5'
-    ovirt_engine_setup_organization: 'rhv.redhat.com'
-    ovirt_engine_setup_product_type: 'rhv'
   roles:
     - engine_setup
   collections:

--- a/roles/engine_setup/defaults/main.yml
+++ b/roles/engine_setup/defaults/main.yml
@@ -26,7 +26,6 @@ ovirt_engine_setup_firewall_manager: "firewalld"
 ovirt_engine_setup_update_setup_packages: false
 ovirt_engine_setup_offline: false
 
-ovirt_engine_setup_product_type: oVirt
 ovirt_engine_setup_package_list: []
 ovirt_engine_setup_use_remote_answer_file: false
 

--- a/roles/engine_setup/examples/engine-deploy.yml
+++ b/roles/engine_setup/examples/engine-deploy.yml
@@ -4,7 +4,6 @@
   vars_files:
     - passwords.yml
   vars:
-    ovirt_engine_setup_product_type: "ovirt"
     ovirt_engine_setup_version: "4.5"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_dwh_db_host: "localhost"

--- a/roles/engine_setup/examples/engine-upgrade.yml
+++ b/roles/engine_setup/examples/engine-upgrade.yml
@@ -4,7 +4,6 @@
   vars_files:
     - passwords.yml
   vars:
-    ovirt_engine_setup_product_type: "ovirt"
     ovirt_engine_setup_version: "{{ ovirt_engine_setup_version }}"
     ovirt_engine_setup_organization: "example.com"
     ovirt_engine_setup_configure_iso_domain: true

--- a/roles/engine_setup/tasks/install_packages.yml
+++ b/roles/engine_setup/tasks/install_packages.yml
@@ -3,20 +3,6 @@
   ansible.builtin.dnf:
     name: "ovirt-engine"
     state: present
-  when: ovirt_engine_setup_product_type | lower == 'ovirt'
-
-- name: Check if rhevm package is installed
-  ansible.builtin.dnf:
-    list: "rhevm"
-  when: ovirt_engine_setup_product_type | lower == 'rhv' and ansible_os_family == 'RedHat'
-  register: rhevm_installed
-
-- name: Install RHV package
-  ansible.builtin.dnf:
-    name: "{{ 'rhevm' if ovirt_engine_setup_version is version('4.2', '<') else 'rhvm' }}"
-    state: present
-  when: ovirt_engine_setup_product_type | lower == 'rhv' and rhevm_installed.results | default([]) | selectattr( 'yumstate', 'match', 'installed') | list | length
-    == 0
 
 - name: Install rest of the packages required for oVirt Engine deployment
   ansible.builtin.dnf:


### PR DESCRIPTION
We no longer support or maintain RHV deployments,
so we no longer need the product type logic.