### PR TITLE
Fix missing cluster name when starting VM

### DIFF
--- a/changelogs/fragments/780-fix-missing-cluster-name.yaml
+++ b/changelogs/fragments/780-fix-missing-cluster-name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix missing cluster name when starting VM (https://github.com/oVirt/ovirt-ansible-collection/pull/780)

--- a/roles/vm_infra/tasks/manage_state.yml
+++ b/roles/vm_infra/tasks/manage_state.yml
@@ -75,6 +75,7 @@
     auth: "{{ ovirt_auth }}"
     state: "{{ current_vm.state | default(current_vm.profile.state) | default('present') }}"
     name: "{{ current_vm.name }}"
+    cluster: "{{ current_vm.cluster | default(current_vm.profile.cluster) | default(omit) }}"
     sysprep: "{{ (sysprep | length > 0) | ternary(sysprep, omit) }}"
     cloud_init: "{{ (cloud_init | length > 0) | ternary(cloud_init, omit) }}"
     cloud_init_persist: "{{ current_vm.cloud_init_persist | default(current_vm.profile.cloud_init_persist) | default(omit) }}"


### PR DESCRIPTION
Issue:
When the VM gets started on specific cluster with the vm_infra role it fails with error:
```
Fault reason is "Incomplete parameters". Fault detail is "Vm [cluster.id|name] required for add". HTTP response code is 400.
```

This is caused because the role does not pass the cluster information to the ovirt_vm module.

Thank you @gsigrisi for finidng this issue!