### PR TITLE
ovirt_host_network: commit on ip/properties change

### DIFF
--- a/changelogs/fragments/787-ovirt_host_network-commit_on_ip_change.yml
+++ b/changelogs/fragments/787-ovirt_host_network-commit_on_ip_change.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_host_network - commit on ip/properties change (https://github.com/oVirt/ovirt-ansible-collection/pull/787).

--- a/plugins/modules/ovirt_host_network.py
+++ b/plugins/modules/ovirt_host_network.py
@@ -588,6 +588,8 @@ def main():
                 elif module.params['save']:
                     setup_params['post_action'] = host_networks_module._action_save_configuration
                 host_networks_module.action(**setup_params)
+        elif host_networks_module.changed and module.params['save']:
+            host_networks_module._action_save_configuration(host)
 
         nic = search_by_name(nics_service, nic_name)
         module.exit_json(**{

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -1,0 +1,10 @@
+.automation/build.sh shebang
+plugins/callback/stdout.py shebang
+roles/disaster_recovery/files/bcolors.py shebang
+roles/disaster_recovery/files/fail_back.py shebang
+roles/disaster_recovery/files/fail_over.py shebang
+roles/disaster_recovery/files/generate_mapping.py shebang
+roles/disaster_recovery/files/generate_vars.py shebang
+roles/disaster_recovery/files/generate_vars_test.py shebang
+roles/disaster_recovery/files/validator.py shebang
+roles/disaster_recovery/files/ovirt-dr shebang


### PR DESCRIPTION
When 'save' is set to 'True', then we except that the changes are saved. Now this wasn't the case when for example only the IP address of an attachment was changed, but no new attachment was added.

This was because the `has_update` function does not return True when there was a change in update_custom_properties or update_address. Making it return True does not fix the issue neither, as oVirt does not save the changes in the 'setupnetworks' call when the IP was already changed before (via the update_address call).

Therefor, the fix here is to call commit_net_config when there was a change but setupnetworks was not executed.
If there for example is an IP change and a new attachment, then the 'commit_on_success' in 'setupnetworks' do cause everything to get saved, even if the IP was already modified in update_address.