### PR TITLE
ovirt_snapshot: fail task when engine snapshot job fails (#777)

### DIFF
--- a/changelogs/fragments/777-ovirt_snapshot-fail-on-engine-job-failure.yml
+++ b/changelogs/fragments/777-ovirt_snapshot-fail-on-engine-job-failure.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ovirt_snapshot - fail the task when the engine snapshot creation job fails, and refresh the returned snapshot entity so the reported status reflects the final state (https://github.com/oVirt/ovirt-ansible-collection/issues/777).

--- a/plugins/modules/ovirt_snapshot.py
+++ b/plugins/modules/ovirt_snapshot.py
@@ -204,6 +204,7 @@ except ImportError:
 import os
 import ssl
 import time
+import uuid
 
 from ansible.module_utils.six.moves.http_client import HTTPSConnection
 from ansible.module_utils.six.moves.urllib.parse import urlparse
@@ -364,6 +365,7 @@ def create_snapshot(module, vm_service, snapshots_service, connection):
         snapshots_service.snapshot_service(module.params['snapshot_id'])
     )
     if snapshot is None:
+        correlation_id = str(uuid.uuid4())
         if not module.check_mode:
             disk_attachments_id = set(
                 get_disk_attachment(disk, vm_service.disk_attachments_service().list(), connection).id
@@ -375,15 +377,26 @@ def create_snapshot(module, vm_service, snapshots_service, connection):
                     description=module.params.get('description'),
                     persist_memorystate=module.params.get('use_memory'),
                     disk_attachments=[otypes.DiskAttachment(disk=otypes.Disk(id=da_id)) for da_id in disk_attachments_id] if disk_attachments_id else None
-                )
+                ),
+                query={'correlation_id': correlation_id},
             )
         changed = True
+        snapshot_service = snapshots_service.snapshot_service(snapshot.id)
         wait(
-            service=snapshots_service.snapshot_service(snapshot.id),
-            condition=lambda snap: snap.snapshot_status == otypes.SnapshotStatus.OK,
+            service=snapshot_service,
+            condition=lambda snap: snap is not None and snap.snapshot_status == otypes.SnapshotStatus.OK,
+            fail_condition=lambda snap: snap is None,
             wait=module.params['wait'],
             timeout=module.params['timeout'],
         )
+        if not module.check_mode and module.params['wait']:
+            jobs_service = connection.system_service().jobs_service()
+            for job in jobs_service.list(search='correlation_id=%s' % correlation_id):
+                if job.status in [otypes.JobStatus.FAILED, otypes.JobStatus.ABORTED, otypes.JobStatus.UNKNOWN]:
+                    raise Exception(
+                        "Snapshot creation job failed in oVirt: %s" % job.description
+                    )
+            snapshot = get_entity(snapshot_service) or snapshot
     return {
         'changed': changed,
         'id': snapshot.id,


### PR DESCRIPTION
## Summary
Fixes #777 — `ovirt_snapshot` reported success even when the underlying snapshot creation job failed in oVirt engine.

The module now tags the snapshot creation call with a correlation ID, then queries the engine's jobs service after the wait completes and fails the task if the matching job ended in `FAILED`, `ABORTED`, or `UNKNOWN`. The wait condition is also hardened to handle the case where the engine cleans up the snapshot on job failure (entity becomes `None`), and the returned snapshot entity is refreshed so the reported status reflects the final state.

## Changes
- Generate a correlation ID and pass it to `snapshots_service.add(...)`.
- After waiting for the snapshot to reach `OK`, look up jobs by correlation ID and raise if any non-success status is found.
- Make the wait `condition` `None`-safe and add `fail_condition=lambda snap: snap is None`.
- Refresh the snapshot entity before returning so the result reflects the final engine state.
- Added changelog fragment.